### PR TITLE
Store CIKs in the keychain

### DIFF
--- a/msixvc/src/models/xvd/structs/parsed.rs
+++ b/msixvc/src/models/xvd/structs/parsed.rs
@@ -168,7 +168,7 @@ impl From<raw::XvdHashEntry> for XvdHashEntry {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XvcInfo {
     pub content_id: Uuid,
-    pub xvc_encryption_key_id: HashMap<u16, Uuid>,
+    pub xvc_encryption_key_id: HashMap<u8, Uuid>,
     pub description: [u8; 0x100],
     pub version: u32,
     pub region_count: u32,
@@ -191,7 +191,7 @@ impl From<raw::XvcInfo> for XvcInfo {
                 .xvc_encryption_key_id
                 .into_iter()
                 .enumerate()
-                .map(|(i, uuid)| (i as u16, Uuid::from_bytes_le(uuid)))
+                .map(|(i, uuid)| (i as u8, Uuid::from_bytes_le(uuid)))
                 .filter(|(_i, id)| !id.is_nil())
                 .collect(),
             description: value.description,
@@ -242,7 +242,7 @@ impl From<raw::XvcRegionSpecifier> for XvcRegionSpecifier {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct XvcKeyId(Option<u8>);
 
 impl XvcKeyId {

--- a/msixvc/src/xvd.rs
+++ b/msixvc/src/xvd.rs
@@ -857,7 +857,7 @@ impl XvdFile {
         url: String,
         out: &mut Writer,
         sfile: &SegmentFile,
-        full_key: [u8; 32],
+        content_keys: &HashMap<uuid::Uuid, [u8; 32]>,
         mut progress: Progress,
     ) -> Result<(), Box<dyn std::error::Error>>
     where
@@ -879,6 +879,10 @@ impl XvdFile {
         let file_offset_in_section;
 
         if let Some(s) = s {
+            let full_key = *content_keys
+                .get(&s.key_id)
+                .expect("missing content key, it was checked that it existed");
+
             let mut tweak_key = [0u8; 16];
             let mut data_key = [0u8; 16];
             tweak_key.copy_from_slice(&full_key[..16]);

--- a/msixvc/src/xvd.rs
+++ b/msixvc/src/xvd.rs
@@ -5,7 +5,7 @@ use futures_util::StreamExt;
 use ntfs::{Ntfs, NtfsFile, NtfsReadSeek};
 use reqwest::header::RANGE;
 use std::cmp::min;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::io::{self, Error, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -180,7 +180,7 @@ where
 }
 
 struct XvdEncryptionInfo {
-    full_key: [u8; 32],
+    content_keys: HashMap<uuid::Uuid, [u8; 32]>,
     encrypted_sections: Vec<EncryptedSectionInfo>,
 }
 
@@ -251,13 +251,19 @@ impl<R: Read + Seek> Read for XvdStream<R> {
                     {
                         todo!("Reading outside of the encrypted section in one go is Unsupported");
                     }
+
+                    let key = *encryption_info
+                        .content_keys
+                        .get(&s.key_id)
+                        .expect("missing content key, it was checked that it existed");
+
                     let mut reader = SectionReader::new(
                         &mut self.inner,
                         s.section_offset,
                         s.section_length,
                         s.header_id,
                         s.vduid,
-                        encryption_info.full_key,
+                        key,
                         s.data_units.as_deref(),
                     );
                     return reader
@@ -401,6 +407,8 @@ pub struct EncryptedSectionInfo {
     header_id: XvcRegionId,
     vduid: [u8; 8],
 
+    key_id: uuid::Uuid,
+
     // If integrity is enabled, this must contain one entry per page in the section.
     // If integrity is disabled, use page_in_section as the data unit instead.
     data_units: Option<Vec<u32>>,
@@ -422,6 +430,14 @@ pub struct SegmentFile {
 impl XvdFile {
     pub fn content_id(&self) -> uuid::Uuid {
         self.header.vduid
+    }
+
+    /// Returns a list of the CIKs (Content Integrity Keys) required to decrypt this XVD file.
+    pub fn required_ciks(&self) -> HashSet<uuid::Uuid> {
+        self.encrypted_section_infos
+            .iter()
+            .map(|section| section.key_id)
+            .collect()
     }
 
     fn non_encrypted_prefix_len(&self, start: u64, len: u64) -> u64 {
@@ -467,19 +483,21 @@ impl XvdFile {
         let mut region_headers: Vec<XvcRegionHeader> = Vec::new();
 
         // TODO: Check if we have proper content type
-        if xvd_header.xvc_data_length > 0 {
-            file.seek(std::io::SeekFrom::Start(xvc_info_offset))
-                .await
-                .expect("Unable to seek");
-            let Ok(xvc_info) = read_struct!(XvcInfo, file);
+        if xvd_header.xvc_data_length == 0 {
+            return Err(Box::new(std::io::Error::other("missing XVC data region")));
+        }
 
-            let region_count = xvc_info.region_count;
+        file.seek(std::io::SeekFrom::Start(xvc_info_offset))
+            .await
+            .expect("Unable to seek");
+        let Ok(xvc_info) = read_struct!(XvcInfo, file);
 
-            if xvc_info.version >= 1 {
-                for _ in 0..region_count {
-                    let region_header = read_struct!(XvcRegionHeader, file)?;
-                    region_headers.push(region_header);
-                }
+        let region_count = xvc_info.region_count;
+
+        if xvc_info.version >= 1 {
+            for _ in 0..region_count {
+                let region_header = read_struct!(XvcRegionHeader, file)?;
+                region_headers.push(region_header);
             }
         }
 
@@ -499,16 +517,23 @@ impl XvdFile {
         let mut enc_sections: Vec<EncryptedSectionInfo> = vec![];
         let mut reader = BufReader::with_capacity(PAGES_PER_BLOCK * XvdHashEntry::RAW_SIZE, file);
         for h in region_headers {
-            let key_id = h.key_id;
-            let length = h.length;
-            match key_id.get() {
-                None => continue,
-                Some(0) => (),
-                Some(n) => todo!("KeyID other than 0 or unencrypted is not supported, found {n}"),
-            }
+            let key_id = {
+                let Some(id) = h.key_id.get() else {
+                    continue;
+                };
+
+                match xvc_info.xvc_encryption_key_id.get(&id) {
+                    Some(uuid) => *uuid,
+                    None => {
+                        return Err(Box::new(std::io::Error::other(format!(
+                            "missing key_id in XVC encryption info: {id}"
+                        ))));
+                    }
+                }
+            };
 
             let start_page = offset_to_page_number(h.offset - user_data_offset);
-            let num_pages = bytes_to_pages(length);
+            let num_pages = bytes_to_pages(h.length);
             let mut data_units: Vec<u32> = Vec::with_capacity(num_pages as usize);
             let mut data_hashs: Vec<[u8; 20]> = Vec::with_capacity(num_pages as usize);
 
@@ -545,6 +570,7 @@ impl XvdFile {
                 section_length: h.length,
                 header_id: h.region_id,
                 vduid: xvd_header.vduid.to_bytes_le()[..8].try_into().unwrap(),
+                key_id,
                 data_units: Some(data_units),
                 first_segment_index: h.first_segment_index,
                 data_hashs,
@@ -996,8 +1022,17 @@ pub fn unpack_file(
     xvd: XvdFile,
     path: String,
     destination: String,
-    full_key: [u8; 32],
+    content_keys: HashMap<uuid::Uuid, [u8; 32]>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // Check that every content key has been provided
+    for key_id in xvd.required_ciks() {
+        if !content_keys.contains_key(&key_id) {
+            return Err(Box::new(std::io::Error::other(format!(
+                "missing content integrity key: {key_id}"
+            ))));
+        }
+    }
+
     let sfile = std::fs::File::open(path)?;
     let block_size = 4096; //xvd.header.block_size;
     let gp = gpt::GptConfig::new()
@@ -1039,7 +1074,7 @@ pub fn unpack_file(
         offset: partition_offset,
         end_offset: partition_offset + part_len,
         encryption_info: Some(XvdEncryptionInfo {
-            full_key,
+            content_keys,
             encrypted_sections: xvd.encrypted_section_infos,
         }),
     };

--- a/xodus-cli/src/commands/extract.rs
+++ b/xodus-cli/src/commands/extract.rs
@@ -24,8 +24,9 @@ pub async fn run(
             game_splicense.content_keys.len()
         )
     }
-    if let Some((_, content_key)) = game_splicense.content_keys.into_iter().next() {
+    if let Some((uuid, content_key)) = game_splicense.content_keys.into_iter().next() {
         let unpacked = content_key.unpack(&key).expect("failed to unpack");
+        tokens.save_cik(uuid, unpacked).unwrap();
         unpack_file(xvd, path.to_string(), destination.to_string(), *unpacked).expect("unpack ok");
     }
 }

--- a/xodus-cli/src/commands/extract.rs
+++ b/xodus-cli/src/commands/extract.rs
@@ -1,6 +1,8 @@
 use msixvc::xvd::{XvdFile, unpack_file};
 use xodus::tokens::TokenManager;
 
+use std::collections::{HashMap, HashSet};
+
 use crate::license::get_license;
 pub async fn run(
     client: &reqwest::Client,
@@ -12,21 +14,44 @@ pub async fn run(
     let xvd = XvdFile::parse_file(path.to_string())
         .await
         .expect("Failed to parse");
-    let license = get_license(client, tokens, xvd.content_id().to_string(), market).await;
-    if let Err(err) = license {
-        eprintln!("{}", err);
-        return;
+
+    let required_ciks = xvd.required_ciks();
+
+    let mut content_keys: HashMap<uuid::Uuid, [u8; 32]> = HashMap::new();
+    let mut missing_ciks: HashSet<uuid::Uuid> = HashSet::new();
+
+    for cik_uuid in required_ciks {
+        match tokens.get_cik(cik_uuid).unwrap() {
+            Some(cik) => {
+                content_keys.insert(cik_uuid, *cik);
+            }
+            None => {
+                missing_ciks.insert(cik_uuid);
+            }
+        }
     }
-    let (key, game_splicense) = license.unwrap();
-    if game_splicense.content_keys.len() != 1 {
-        eprintln!(
-            "unexpected number of content keys {}",
-            game_splicense.content_keys.len()
-        )
+
+    if !missing_ciks.is_empty() {
+        let license = get_license(client, tokens, xvd.content_id().to_string(), market).await;
+        if let Err(err) = license {
+            eprintln!("{}", err);
+            return;
+        }
+
+        let (key, game_splicense) = license.unwrap();
+        for (uuid, content_key) in game_splicense.content_keys {
+            let unpacked = content_key.unpack(&key).expect("failed to unpack");
+            tokens.save_cik(uuid, unpacked).unwrap();
+
+            if missing_ciks.remove(&uuid) {
+                content_keys.insert(uuid, *unpacked);
+            }
+        }
+
+        if !missing_ciks.is_empty() {
+            panic!("missing CIK in game splicense: {:?}", missing_ciks)
+        }
     }
-    if let Some((uuid, content_key)) = game_splicense.content_keys.into_iter().next() {
-        let unpacked = content_key.unpack(&key).expect("failed to unpack");
-        tokens.save_cik(uuid, unpacked).unwrap();
-        unpack_file(xvd, path.to_string(), destination.to_string(), *unpacked).expect("unpack ok");
-    }
+
+    unpack_file(xvd, path.to_string(), destination.to_string(), content_keys).expect("unpack ok");
 }

--- a/xodus-cli/src/commands/license.rs
+++ b/xodus-cli/src/commands/license.rs
@@ -19,6 +19,7 @@ pub async fn run(
     tokio::fs::create_dir_all(&ciks).await.unwrap();
     for (uuid, content_key) in game_splicense.content_keys {
         let unpacked = content_key.unpack(&key).expect("failed to unpack");
+        tokens.save_cik(uuid, unpacked).unwrap();
         let mut file = OpenOptions::new()
             .create(true)
             .write(true)

--- a/xodus-cli/src/commands/streaming.rs
+++ b/xodus-cli/src/commands/streaming.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, path::Path, vec};
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+    vec,
+};
 
 use fs2::available_space;
 use futures_util::{StreamExt, stream};
@@ -259,35 +263,50 @@ pub async fn run(
         }
     }
 
-    let license = get_license(
-        client,
-        tokens,
-        remote_xvd.content_id().to_string(),
-        market.unwrap_or("neutral".to_string()),
-    )
-    .await;
-    if let Err(err) = license {
-        eprintln!("{}", err);
-        return;
-    }
-    let (key, game_splicense) = license.unwrap();
-    if game_splicense.content_keys.len() != 1 {
-        eprintln!(
-            "unexpected number of content keys {}",
-            game_splicense.content_keys.len()
-        );
-        return;
+    let required_ciks = remote_xvd.required_ciks();
+
+    let mut content_keys: HashMap<uuid::Uuid, [u8; 32]> = HashMap::new();
+    let mut missing_ciks: HashSet<uuid::Uuid> = HashSet::new();
+
+    for cik_uuid in required_ciks {
+        match tokens.get_cik(cik_uuid).unwrap() {
+            Some(cik) => {
+                content_keys.insert(cik_uuid, *cik);
+            }
+            None => {
+                missing_ciks.insert(cik_uuid);
+            }
+        }
     }
 
-    let full_key = {
-        let Some((uuid, content_key)) = game_splicense.content_keys.into_iter().next() else {
+    if !missing_ciks.is_empty() {
+        let license = get_license(
+            client,
+            tokens,
+            remote_xvd.content_id().to_string(),
+            market.unwrap_or("neutral".to_string()),
+        )
+        .await;
+
+        if let Err(err) = license {
+            eprintln!("{}", err);
             return;
-        };
+        }
 
-        let key = content_key.unpack(&key).expect("failed to unpack");
-        tokens.save_cik(uuid, key).unwrap();
-        key
-    };
+        let (key, game_splicense) = license.unwrap();
+        for (uuid, content_key) in game_splicense.content_keys {
+            let unpacked = content_key.unpack(&key).expect("failed to unpack");
+            tokens.save_cik(uuid, unpacked).unwrap();
+
+            if missing_ciks.remove(&uuid) {
+                content_keys.insert(uuid, *unpacked);
+            }
+        }
+
+        if !missing_ciks.is_empty() {
+            panic!("missing CIK in game splicense: {:?}", missing_ciks)
+        }
+    }
 
     let total_size = rfiles
         .iter()
@@ -359,6 +378,8 @@ pub async fn run(
     .for_each_concurrent(parallel.unwrap_or(4), |(id, job)| {
         let tx = tx.clone();
         let client = client.clone();
+        let content_keys = &content_keys;
+
         async move {
             let target_file = out.join(job.name.replace("\\", "/"));
             if let Some(folder) = target_file.parent() {
@@ -404,7 +425,7 @@ pub async fn run(
                     url.to_owned(),
                     &mut fout,
                     &job.content,
-                    *full_key,
+                    content_keys,
                     progress,
                 )
                 .await

--- a/xodus-cli/src/commands/streaming.rs
+++ b/xodus-cli/src/commands/streaming.rs
@@ -278,11 +278,16 @@ pub async fn run(
         );
         return;
     }
-    let Some((_, content_key)) = game_splicense.content_keys.into_iter().next() else {
-        return;
-    };
 
-    let full_key = content_key.unpack(&key).expect("failed to unpack");
+    let full_key = {
+        let Some((uuid, content_key)) = game_splicense.content_keys.into_iter().next() else {
+            return;
+        };
+
+        let key = content_key.unpack(&key).expect("failed to unpack");
+        tokens.save_cik(uuid, key).unwrap();
+        key
+    };
 
     let total_size = rfiles
         .iter()

--- a/xodus/src/licensing/splicense.rs
+++ b/xodus/src/licensing/splicense.rs
@@ -26,6 +26,7 @@ use std::{collections::HashMap, io, io::Read, ops::Deref};
 use aes::cipher::{BlockCipherDecrypt, KeyInit};
 use base64::prelude::*;
 use num_enum::TryFromPrimitive;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use zerocopy::{FromBytes, IntoBytes, transmute};
 
@@ -103,7 +104,7 @@ pub struct DeviceKey([u8; 16]);
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct PackedContentKey([u8; 40]);
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContentKey([u8; 32]);
 
 fn read_array<const N: usize, R: Read>(mut reader: R) -> io::Result<[u8; N]> {

--- a/xodus/src/models/secrets.rs
+++ b/xodus/src/models/secrets.rs
@@ -62,12 +62,6 @@ impl From<soap::RequestSecurityTokenResponse> for Token {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct TokenStore {
-    #[serde(flatten)]
-    pub tokens: std::collections::HashMap<String, Token>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
 pub struct User {
     pub puid: String,
     pub username: String,

--- a/xodus/src/tokens/manager.rs
+++ b/xodus/src/tokens/manager.rs
@@ -143,8 +143,8 @@ impl TokenManager {
         let Some(bytes) = backend.get(key)? else {
             return Ok(None);
         };
-        let store: TokenStore = serde_json::from_slice(&bytes)?;
-        Ok(store.tokens.get(address).cloned())
+        let mut store: TokenStore = serde_json::from_slice(&bytes)?;
+        Ok(store.tokens.remove(address))
     }
 
     fn write_token_store(

--- a/xodus/src/tokens/manager.rs
+++ b/xodus/src/tokens/manager.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use crate::{
     models::{
-        secrets::{Device, Token, TokenStore, User},
+        secrets::{Device, Token, User},
         xbox::XstsResponse,
     },
     tokens::{
@@ -68,11 +68,11 @@ impl TokenManager {
     // ---- Device STS tokens (keyed by SOAP "applies_to" address) -----------
 
     pub fn get_device_token_for(&self, address: &str) -> Result<Option<Token>, TokenStoreError> {
-        Self::read_token_store(&*self.persistent, keys::DEVICE_TOKENS, address)
+        Self::get_table(&*self.persistent, keys::DEVICE_TOKENS, address)
     }
 
     pub fn save_device_token(&self, address: String, token: Token) -> Result<(), TokenStoreError> {
-        Self::write_token_store(&*self.persistent, keys::DEVICE_TOKENS, address, token)
+        Self::write_table(&*self.persistent, keys::DEVICE_TOKENS, address, token)
     }
 
     pub fn get_device_sts_token(&self) -> Result<Token, TokenStoreError> {
@@ -83,11 +83,11 @@ impl TokenManager {
     // ---- User STS tokens (keyed by SOAP "applies_to" address) --------------
 
     pub fn get_user_token_for(&self, address: &str) -> Result<Option<Token>, TokenStoreError> {
-        Self::read_token_store(&*self.persistent, keys::USER_TOKENS, address)
+        Self::get_table(&*self.persistent, keys::USER_TOKENS, address)
     }
 
     pub fn save_user_token(&self, address: String, token: Token) -> Result<(), TokenStoreError> {
-        Self::write_token_store(&*self.persistent, keys::USER_TOKENS, address, token)
+        Self::write_table(&*self.persistent, keys::USER_TOKENS, address, token)
     }
 
     pub fn get_user_sts_token(&self) -> Result<Token, TokenStoreError> {
@@ -133,33 +133,53 @@ impl TokenManager {
             .set_with_expiry(key, &bytes, Instant::now() + remaining);
     }
 
-    // ---- shared TokenStore read/modify/write helper ---------------------------
+    // ---- shared table read/modify/write helper ---------------------------
 
-    fn read_token_store(
+    /// A table is a collection of indexed elements with the same type, `T`.
+    ///
+    /// Reads a table from the [`TokenBackend`] under `key`.
+    fn read_table<T>(
         backend: &dyn TokenBackend,
         key: &str,
-        address: &str,
-    ) -> Result<Option<Token>, TokenStoreError> {
-        let Some(bytes) = backend.get(key)? else {
-            return Ok(None);
-        };
-        let mut store: TokenStore = serde_json::from_slice(&bytes)?;
-        Ok(store.tokens.remove(address))
+    ) -> Result<HashMap<String, T>, TokenStoreError>
+    where
+        T: for<'de> serde::Deserialize<'de>,
+    {
+        let store = backend
+            .get(key)?
+            .filter(|bytes| !bytes.is_empty())
+            .map(|bytes| serde_json::from_slice::<HashMap<String, T>>(&bytes))
+            .transpose()?;
+
+        Ok(store.unwrap_or_default())
     }
 
-    fn write_token_store(
+    /// Gets an element from a table of elements of type `T`.
+    fn get_table<T>(
         backend: &dyn TokenBackend,
         key: &str,
-        address: String,
-        token: Token,
-    ) -> Result<(), TokenStoreError> {
-        let mut tokens: HashMap<String, Token> = match backend.get(key)? {
-            Some(bytes) if !bytes.is_empty() => {
-                serde_json::from_slice::<TokenStore>(&bytes)?.tokens
-            }
-            _ => HashMap::new(),
-        };
-        tokens.insert(address, token);
-        backend.set(key, &serde_json::to_vec(&TokenStore { tokens })?)
+        index: &str,
+    ) -> Result<Option<T>, TokenStoreError>
+    where
+        T: for<'de> serde::Deserialize<'de>,
+    {
+        let mut store = Self::read_table(backend, key)?;
+        Ok(store.remove(index))
+    }
+
+    /// Appends an element into a table of elements of type `T`.
+    fn write_table<T>(
+        backend: &dyn TokenBackend,
+        key: &str,
+        index: String,
+        value: T,
+    ) -> Result<(), TokenStoreError>
+    where
+        T: for<'de> serde::Deserialize<'de> + serde::Serialize,
+    {
+        let mut store: HashMap<String, T> = Self::read_table(backend, key)?;
+        store.insert(index, value);
+
+        backend.set(key, &serde_json::to_vec(&store)?)
     }
 }

--- a/xodus/src/tokens/manager.rs
+++ b/xodus/src/tokens/manager.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use crate::{
+    licensing::splicense::ContentKey,
     models::{
         secrets::{Device, Token, User},
         xbox::XstsResponse,
@@ -16,6 +17,7 @@ mod keys {
     pub const DEVICE_TOKENS: &str = "device-tokens";
     pub const USER_TOKENS: &str = "user-tokens";
     pub const USER_INFO: &str = "user-DA";
+    pub const CONTENT_INTEGRITY_KEYS: &str = "content-integrity-keys";
 }
 
 pub const PASSPORT_STS: &str = "http://Passport.NET/STS";
@@ -131,6 +133,25 @@ impl TokenManager {
         let _ = self
             .ephemeral
             .set_with_expiry(key, &bytes, Instant::now() + remaining);
+    }
+
+    // ---- CIK Content Integrity Key for MSIXVC decryption ----------------------
+
+    pub fn get_cik(&self, uuid: uuid::Uuid) -> Result<Option<ContentKey>, TokenStoreError> {
+        Self::get_table(
+            &*self.persistent,
+            keys::CONTENT_INTEGRITY_KEYS,
+            &uuid.hyphenated().to_string(),
+        )
+    }
+
+    pub fn save_cik(&self, uuid: uuid::Uuid, cik: ContentKey) -> Result<(), TokenStoreError> {
+        Self::write_table(
+            &*self.persistent,
+            keys::CONTENT_INTEGRITY_KEYS,
+            uuid.hyphenated().to_string(),
+            cik,
+        )
     }
 
     // ---- shared table read/modify/write helper ---------------------------


### PR DESCRIPTION
When a CIK (Content Integrity Key) is downloaded, store it in the keychain instead of forgetting it. Only try to fetch a CIK if it's not found in the keychain first.

Implement reading CIKs from the keychain for both local extract and streaming.

Also, now decrypting a XVD file that contains multiple encrypted regions with different keys is allowed (before it panicked with a todo).