### PR TITLE
Add Trial variant to DeviceCredential enum

### DIFF
--- a/xodus/src/models/devicecredential.rs
+++ b/xodus/src/models/devicecredential.rs
@@ -155,6 +155,7 @@ pub enum LicenseType {
     User,
     Full,
     KeyHolder,
+    Trial,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
It allows you to install games that have trial variants.