### PR TITLE
Remove `read_struct!` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,7 +2817,6 @@ name = "msixvc"
 version = "0.1.0"
 dependencies = [
  "aes 0.9.0",
- "async-trait",
  "bitflags 2.13.0",
  "bytes",
  "chrono",

--- a/msixvc/Cargo.toml
+++ b/msixvc/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 tokio = { workspace = true }
 reqwest = { workspace = true }
 aes = "0.9.0"
-async-trait = "0.1.89"
 bitflags = "2.13.0"
 bytes = "1.12.0"
 chrono = { workspace = true }

--- a/msixvc/src/models/common.rs
+++ b/msixvc/src/models/common.rs
@@ -75,6 +75,14 @@ macro_rules! impl_struct {
                 Self::try_from(raw)
             }
 
+            /// Panics if the slice length is less than [`Self::RAW_SIZE`].
+            pub fn from_slice(
+                slice: &[u8],
+            ) -> Result<Self, <Self as TryFrom<raw::$parsed>>::Error> {
+                assert!(slice.len() >= Self::RAW_SIZE);
+                Self::from_array(slice.try_into().unwrap())
+            }
+
             pub async fn read<R: tokio::io::AsyncRead + Unpin>(
                 mut reader: R,
             ) -> Result<

--- a/msixvc/src/models/common.rs
+++ b/msixvc/src/models/common.rs
@@ -80,7 +80,7 @@ macro_rules! impl_struct {
                 slice: &[u8],
             ) -> Result<Self, <Self as TryFrom<raw::$parsed>>::Error> {
                 assert!(slice.len() >= Self::RAW_SIZE);
-                Self::from_array(slice.try_into().unwrap())
+                Self::from_array(slice[..Self::RAW_SIZE].try_into().unwrap())
             }
 
             pub async fn read<R: tokio::io::AsyncRead + Unpin>(

--- a/msixvc/src/models/common.rs
+++ b/msixvc/src/models/common.rs
@@ -54,49 +54,42 @@ impl std::fmt::Debug for Version {
     }
 }
 
-/// An XVD binary structure that can be decoded from bytes.
-///
-/// The conversion from bytes isn't implemented as a trait method because the compiler
-/// hates generic constants: "generic parameters may not be used in const operations".
-///
-/// Implementing this trait means that `impl TryFrom<[u8; XvdStruct::RAW_SIZE]>
-/// for Self` exists.
-pub trait XvcStruct: Sized {
-    const RAW_SIZE: usize;
-}
+#[derive(thiserror::Error, Debug)]
+pub enum ReadError<E> {
+    #[error(transparent)]
+    Io(#[from] tokio::io::Error),
 
-// This is a macro because the compiler can't handle const generics
-macro_rules! read_struct {
-    ($t:ty, $reader:expr) => {{
-        use tokio::io::AsyncReadExt;
-        let mut buf = [0u8; <$t as XvcStruct>::RAW_SIZE];
-        $reader.read_exact(&mut buf).await?;
-        TryInto::<$t>::try_into(buf)
-    }};
+    #[error(transparent)]
+    Parse(E),
 }
 
 macro_rules! impl_struct {
     ($parsed:ident) => {
-        impl XvcStruct for $parsed {
-            const RAW_SIZE: usize = core::mem::size_of::<raw::$parsed>();
-        }
+        impl $parsed {
+            pub const RAW_SIZE: usize = core::mem::size_of::<raw::$parsed>();
 
-        #[allow(clippy::infallible_try_from)]
-        impl TryFrom<[u8; <$parsed as XvcStruct>::RAW_SIZE]> for $parsed {
-            type Error = <Self as TryFrom<raw::$parsed>>::Error;
-
-            fn try_from(
-                value: [u8; <$parsed as XvcStruct>::RAW_SIZE],
-            ) -> Result<Self, Self::Error> {
-                let raw: raw::$parsed = zerocopy::transmute!(value);
+            pub fn from_array(
+                array: [u8; Self::RAW_SIZE],
+            ) -> Result<Self, <Self as TryFrom<raw::$parsed>>::Error> {
+                let raw: raw::$parsed = zerocopy::transmute!(array);
                 Self::try_from(raw)
+            }
+
+            pub async fn read<R: tokio::io::AsyncRead + Unpin>(
+                mut reader: R,
+            ) -> Result<
+                Self,
+                crate::models::common::ReadError<<Self as TryFrom<raw::$parsed>>::Error>,
+            > {
+                let mut array = [0u8; Self::RAW_SIZE];
+                tokio::io::AsyncReadExt::read_exact(&mut reader, &mut array).await?;
+                Self::from_array(array).map_err(|e| crate::models::common::ReadError::Parse(e))
             }
         }
     };
 }
 
 pub(crate) use impl_struct;
-pub(crate) use read_struct;
 
 #[cfg(test)]
 mod tests {

--- a/msixvc/src/models/xsp/structs.rs
+++ b/msixvc/src/models/xsp/structs.rs
@@ -1,8 +1,9 @@
-pub mod parsed;
-pub mod raw;
+mod parsed;
+mod raw;
 
-use crate::models::common::*;
 pub use parsed::*;
+
+use crate::models::common::impl_struct;
 
 impl_struct!(XspHeader);
 impl_struct!(XspPatchRecord);

--- a/msixvc/src/models/xsp/structs/parsed.rs
+++ b/msixvc/src/models/xsp/structs/parsed.rs
@@ -1,5 +1,5 @@
+use super::raw;
 use crate::models::common::Version;
-use crate::models::xsp::raw;
 
 #[derive(Debug, Clone)]
 pub struct XspHeader {

--- a/msixvc/src/xsp.rs
+++ b/msixvc/src/xsp.rs
@@ -1,4 +1,3 @@
-use crate::models::common::*;
 use crate::models::xsp::{XspHeader, XspPatchRecord};
 use tokio::io::{AsyncRead, AsyncSeek};
 use tokio::io::{AsyncSeekExt, BufReader};
@@ -15,13 +14,13 @@ impl XspFile {
     {
         let mut file = BufReader::new(file);
 
-        let header = read_struct!(XspHeader, file)?;
+        let header = XspHeader::read(&mut file).await?;
         let mut entries = Vec::with_capacity(header.record_count as usize);
         file.seek(std::io::SeekFrom::Start(header.page_size as u64))
             .await?;
 
         for _ in 0..header.record_count {
-            let record = read_struct!(XspPatchRecord, file)?;
+            let record = XspPatchRecord::read(&mut file).await?;
             entries.push(record);
         }
 

--- a/msixvc/src/xvd.rs
+++ b/msixvc/src/xvd.rs
@@ -25,7 +25,6 @@ use crate::models::xvd::{
     XvdUserDataHeader, XvdUserDataPackageFileEntry, XvdUserDataPackageFilesHeader,
 };
 use crate::streaming_ntfs::collect_ntfs_stream_layouts;
-use async_trait::async_trait;
 
 use crate::crypt::{SectionReader, Tweak, decrypt_page_xts};
 use crate::math::{
@@ -155,27 +154,6 @@ impl<R: Write + Seek> Write for SyncSubstream<R> {
 
     fn flush(&mut self) -> io::Result<()> {
         self.inner.flush()
-    }
-}
-
-#[async_trait]
-pub trait AsyncReadSeek {
-    async fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()>;
-    async fn seek(&mut self, pos: SeekFrom) -> io::Result<u64>;
-}
-
-#[async_trait]
-impl<T> AsyncReadSeek for T
-where
-    T: AsyncRead + AsyncSeek + Unpin + Send,
-{
-    async fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
-        AsyncReadExt::read_exact(self, buf).await?;
-        Ok(())
-    }
-
-    async fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        AsyncSeekExt::seek(self, pos).await
     }
 }
 

--- a/msixvc/src/xvd.rs
+++ b/msixvc/src/xvd.rs
@@ -19,7 +19,6 @@ use tokio::{
 use tokio_util::io::SyncIoBridge;
 use zerocopy::IntoBytes;
 
-use crate::models::common::*;
 use crate::models::xvd::{
     PAGE_SIZE, PAGES_PER_BLOCK, XvdSegmentMetadataHeader, XvdSegmentMetadataSegment,
     XvdUserDataHeader, XvdUserDataPackageFileEntry, XvdUserDataPackageFilesHeader,
@@ -436,7 +435,7 @@ impl XvdFile {
     where
         Reader: AsyncRead + AsyncSeek + Unpin,
     {
-        let xvd_header = read_struct!(XvdHeader, file)?;
+        let xvd_header = XvdHeader::read(&mut file).await?;
 
         let mdu_offset = xvd_header.mdu_offset();
         let (_hash_tree_levels, hash_tree_page_count) = xvd_header.hash_tree_info();
@@ -449,13 +448,13 @@ impl XvdFile {
             file.seek(std::io::SeekFrom::Start(xvc_info_offset))
                 .await
                 .expect("Unable to seek");
-            let Ok(xvc_info) = read_struct!(XvcInfo, file);
+            let xvc_info = XvcInfo::read(&mut file).await?;
 
             let region_count = xvc_info.region_count;
 
             if xvc_info.version >= 1 {
                 for _ in 0..region_count {
-                    let region_header = read_struct!(XvcRegionHeader, file)?;
+                    let region_header = XvcRegionHeader::read(&mut file).await?;
                     region_headers.push(region_header);
                 }
             }
@@ -512,7 +511,7 @@ impl XvdFile {
                     + (entry_start * XvdHashEntry::RAW_SIZE as u64);
                 reader.seek(SeekFrom::Start(read_offset)).await?;
                 for _ in 0..run_length {
-                    let Ok(hash) = read_struct!(XvdHashEntry, reader);
+                    let hash = XvdHashEntry::read(&mut reader).await?;
                     data_units.push(hash.unit);
                     data_hashs.push(hash.block_hash);
                 }
@@ -547,15 +546,17 @@ impl XvdFile {
 
         let user_data_offset = self.user_data_offset;
         file.seek(SeekFrom::Start(user_data_offset)).await?;
-        let user_data_header = read_struct!(XvdUserDataHeader, file)?;
+        let user_data_header = XvdUserDataHeader::read(&mut file).await?;
         if user_data_header.t == 0 {
             let mut off = user_data_offset + user_data_header.length as u64;
             file.seek(SeekFrom::Start(off)).await?;
-            let user_data_package_files_header = read_struct!(XvdUserDataPackageFilesHeader, file)?;
+            let user_data_package_files_header =
+                XvdUserDataPackageFilesHeader::read(&mut file).await?;
             off += XvdUserDataPackageFilesHeader::RAW_SIZE as u64;
             for _ in 0..user_data_package_files_header.file_count {
                 file.seek(SeekFrom::Start(off)).await?;
-                let user_data_package_file_entry = read_struct!(XvdUserDataPackageFileEntry, file)?;
+                let user_data_package_file_entry =
+                    XvdUserDataPackageFileEntry::read(&mut file).await?;
                 off += XvdUserDataPackageFileEntry::RAW_SIZE as u64;
                 let o = user_data_package_file_entry.offset;
                 let s: u32 = user_data_package_file_entry.size;
@@ -588,14 +589,13 @@ impl XvdFile {
     {
         let mut file = BufReader::with_capacity(segment_metadata.length as usize, file);
         file.seek(SeekFrom::Start(segment_metadata.offset)).await?;
-        let segment_header: XvdSegmentMetadataHeader =
-            read_struct!(XvdSegmentMetadataHeader, file)?;
+        let segment_header = XvdSegmentMetadataHeader::read(&mut file).await?;
         let paths_offset =
             segment_header.header_length as u64 + segment_header.segment_count as u64 * 0x10;
 
         let mut segments = vec![];
         for _ in 0..segment_header.segment_count {
-            let segment = read_struct!(XvdSegmentMetadataSegment, file)?;
+            let segment = XvdSegmentMetadataSegment::read(&mut file).await?;
             segments.push(segment);
         }
 


### PR DESCRIPTION
I don't know why I didn't think of this before... If we're using a `impl_struct!` macro, just implement the functions `read` and `from_array` directly for each struct. We couldn't take advantage of the trait anyways because we needed to use a macro to read.

Also, remove a unused trait. 