### PR TITLE
Add manual GPT parse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2820,6 +2829,7 @@ dependencies = [
  "bitflags 2.13.0",
  "bytes",
  "chrono",
+ "crc32fast",
  "futures-util",
  "gpt",
  "ntfs",

--- a/msixvc/Cargo.toml
+++ b/msixvc/Cargo.toml
@@ -18,3 +18,4 @@ thiserror = "2.0.18"
 tokio-util = { version = "0.7.18", features = ["io-util"] }
 uuid = "1.23.1"
 zerocopy = { version = "0.8.48", features = ["derive"] }
+crc32fast = "1.5.0"

--- a/msixvc/src/gpt.rs
+++ b/msixvc/src/gpt.rs
@@ -1,0 +1,248 @@
+//! Read-only, sequential parser for GUID Partition Table (GPT) disks.
+//!
+//! This module reads a GPT-partitioned disk asynchronously without
+//! seeking from an [`AsyncRead`] stream and produces a [`GptDisk`]
+//! containing the parsed header and partition entries.
+//!
+//! Only the **primary** GPT header and partition table (at the start of the
+//! disk) are read. The backup copy at the end of the disk is never consulted.
+
+use crate::models::gpt::*;
+use crate::models::xvd::flags::XvdVolumeFlags;
+
+use std::range::{Range, RangeInclusive};
+
+use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use uuid::Uuid;
+
+#[derive(Clone, Copy, Debug)]
+pub enum LogicalBlockSize {
+    B4096,
+    B512,
+}
+
+impl LogicalBlockSize {
+    const fn get(self) -> usize {
+        match self {
+            Self::B4096 => 4096,
+            Self::B512 => 512,
+        }
+    }
+}
+
+impl From<XvdVolumeFlags> for LogicalBlockSize {
+    fn from(flags: XvdVolumeFlags) -> Self {
+        if flags.contains(XvdVolumeFlags::LEGACY_SECTOR_SIZE) {
+            Self::B512
+        } else {
+            Self::B4096
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GptDisk {
+    logical_block_size: LogicalBlockSize,
+    header: GptHeader,
+    partitions: Vec<PartitionEntry>,
+}
+
+#[derive(Debug, Error)]
+pub enum GptParseError {
+    #[error("IO error: {0}")]
+    IoError(#[from] tokio::io::Error),
+
+    #[error("header: {0}")]
+    InvalidHeader(#[from] GptHeaderParseError),
+
+    #[error(
+        "partition table: invalid crc32 checksum: computed {computed:x}, but header stores {stored:x}"
+    )]
+    InvalidPartitionTableChecksum { computed: u32, stored: u32 },
+
+    #[error(
+        "partition table: entry {partition_index}: invalid partition LBA range: expected in range {header_partitions_lba:?}, got {partition_lba_range:?}"
+    )]
+    OobPartitionEntryLba {
+        partition_index: usize,
+        header_partitions_lba: RangeInclusive<u64>,
+        partition_lba_range: RangeInclusive<u64>,
+    },
+
+    #[error(
+        "header: invalid first partitions LBA: {first_partitions_lba}, but partition table ends at LBA {partition_table_end}"
+    )]
+    InvalidFirstPartitionsLba {
+        first_partitions_lba: u64,
+        partition_table_end: u64,
+    },
+
+    #[error("partition with type GUID {0} not found")]
+    MissingPartition(Uuid),
+}
+
+impl GptDisk {
+    /// Read a primary GPT header and partition table asynchronously.
+    ///
+    /// The reader must be placed at the start of the GPT disk (LBA 0). After this function
+    /// returns, the reader will be positioned at the beginning of the data for the first partition
+    /// (after the partition table). No seeks will be performed.
+    async fn read<R: AsyncRead + Unpin>(
+        mut reader: R,
+        logical_block_size: impl Into<LogicalBlockSize>,
+    ) -> Result<GptDisk, GptParseError> {
+        let logical_block_size = logical_block_size.into();
+        let mut block = vec![0u8; logical_block_size.get()];
+
+        // The first LBA is reserved for backwards-compatibility reasons.
+        reader.read_exact(&mut block).await?;
+
+        // The main GPT header is placed at LBA 1.
+        reader.read_exact(&mut block).await?;
+
+        let header = GptHeader::from_slice(&block)?;
+
+        // Skip empty LBAs until the partition table.
+        // Two LBAs have already been read, the first (reserved) one, and the GPT header.
+        for _ in 2..header.partition_table_lba {
+            reader.read_exact(&mut block).await?;
+        }
+
+        let table_size = header.partition_entries_num * header.partition_entry_size;
+        let table_blocks = table_size.div_ceil(logical_block_size.get());
+        let first_lba_after_partition_table = table_blocks as u64 + header.partition_table_lba;
+
+        // Check that the beginning of the data for the first partition doesn't overlap the partition table.
+        if header.partitions_lba.start < first_lba_after_partition_table {
+            return Err(GptParseError::InvalidFirstPartitionsLba {
+                first_partitions_lba: header.partitions_lba.start,
+                partition_table_end: first_lba_after_partition_table - 1,
+            });
+        }
+
+        // Read the partition table as a bytes Vec to be able to calculate the checksum.
+        let table_bytes = {
+            // Read the partition table as a whole number of logical blocks to keep the reader aligned.
+            let mut table_padded = vec![0u8; table_blocks * logical_block_size.get()];
+            reader.read_exact(&mut table_padded).await?;
+
+            // Trim the padding.
+            table_padded.truncate(table_size);
+            table_padded
+        };
+
+        // Verify that the partition table checksum stored in the header is correct.
+        {
+            let stored = header.partition_table_checksum;
+            let computed = crc32fast::hash(&table_bytes);
+
+            if computed != stored {
+                return Err(GptParseError::InvalidPartitionTableChecksum { computed, stored });
+            }
+        }
+
+        // Push every partition entry into the partition entries Vec.
+        let mut partitions = Vec::with_capacity(header.partition_entries_num);
+
+        for (partition_index, entry) in table_bytes
+            .chunks_exact(header.partition_entry_size)
+            .enumerate()
+        {
+            let Ok(entry) = PartitionEntry::from_slice(entry);
+
+            if entry.partition_type == Uuid::nil() {
+                continue;
+            }
+
+            // Verify that the partition LBA range falls into the usable LBAs as designed by the header.
+            if !header.partitions_lba.contains(&entry.lba_range.start)
+                || !header.partitions_lba.contains(&entry.lba_range.last)
+            {
+                return Err(GptParseError::OobPartitionEntryLba {
+                    partition_index,
+                    header_partitions_lba: header.partitions_lba,
+                    partition_lba_range: entry.lba_range,
+                });
+            }
+
+            partitions.push(entry);
+        }
+
+        // The partition table has been read. Now, skip to the beginning of the data for the first partition.
+        for _ in first_lba_after_partition_table..header.partitions_lba.start {
+            reader.read_exact(&mut block).await?;
+        }
+
+        Ok(GptDisk {
+            logical_block_size,
+            header,
+            partitions,
+        })
+    }
+}
+
+impl GptDisk {
+    /// Finds the first partition with the provided type in the partition table.
+    fn find_partition(&self, partition_type: Uuid) -> Option<&PartitionEntry> {
+        self.partitions
+            .iter()
+            .find(|&part| part.partition_type == partition_type)
+    }
+}
+
+impl GptDisk {
+    /// Positions the given reader at the start of the partition.
+    /// The provided reader must be placed at the start of the LBA range
+    /// designed for partition data.
+    async fn goto_partition<R: AsyncRead + Unpin>(
+        &self,
+        mut reader: R,
+        partition: &PartitionEntry,
+    ) -> Result<(), tokio::io::Error> {
+        // Return fast if the position is already correct.
+        if self.header.partitions_lba.start == partition.lba_range.start {
+            return Ok(());
+        }
+
+        let mut block = vec![0u8; self.logical_block_size.get()];
+
+        // Skip blocks from the start of the partitions LBA to the start of the given partition LBA
+        for _ in self.header.partitions_lba.start..partition.lba_range.start {
+            reader.read_exact(&mut block).await?;
+        }
+
+        Ok(())
+    }
+}
+
+pub async fn goto_windows_basic_data_partition<R: AsyncRead + Unpin>(
+    mut reader: R,
+    logical_block_size: impl Into<LogicalBlockSize>,
+) -> Result<Range<u64>, GptParseError> {
+    // Read the Primary GPT Header.
+    // The seek is now placed at the start of the partition data.
+    let disk = GptDisk::read(&mut reader, logical_block_size).await?;
+
+    // Find the first Windows Basic Data Partition. The XVC drive should have a single partition
+    // of this type, but it is not checked for forward-compatibility reasons. If more than one partition
+    // is found, return the first one which has the correct partition type.
+    const WINDOWS_BASIC_DATA_PARTITION: Uuid = uuid::uuid!("EBD0A0A2-B9E5-4433-87C0-68B6B72699C7");
+    let basic_data_partition = disk.find_partition(WINDOWS_BASIC_DATA_PARTITION).ok_or(
+        GptParseError::MissingPartition(WINDOWS_BASIC_DATA_PARTITION),
+    )?;
+
+    // Move the reader position to the start of the data partition. In practice, the data partition
+    // is the only one, so this does nothing. However, it will work correctly if a partition
+    // which is not Windows Basic Data is added before the data partition.
+    disk.goto_partition(&mut reader, basic_data_partition)
+        .await?;
+
+    // Convert the LBA range of the partition to a bytes range
+    let bytes_part_range = Range {
+        start: basic_data_partition.lba_range.start * disk.logical_block_size.get() as u64,
+        end: (basic_data_partition.lba_range.last + 1) * disk.logical_block_size.get() as u64,
+    };
+
+    Ok(bytes_part_range)
+}

--- a/msixvc/src/lib.rs
+++ b/msixvc/src/lib.rs
@@ -1,5 +1,6 @@
 mod common;
 mod crypt;
+mod gpt;
 pub mod math;
 pub mod models;
 pub mod streaming;

--- a/msixvc/src/models.rs
+++ b/msixvc/src/models.rs
@@ -1,3 +1,4 @@
 pub mod common;
+pub mod gpt;
 pub mod xsp;
 pub mod xvd;

--- a/msixvc/src/models/gpt.rs
+++ b/msixvc/src/models/gpt.rs
@@ -1,0 +1,2 @@
+pub mod structs;
+pub use structs::*;

--- a/msixvc/src/models/gpt/structs.rs
+++ b/msixvc/src/models/gpt/structs.rs
@@ -1,0 +1,9 @@
+mod parsed;
+mod raw;
+
+pub use parsed::*;
+
+use crate::models::common::impl_struct;
+
+impl_struct!(GptHeader);
+impl_struct!(PartitionEntry);

--- a/msixvc/src/models/gpt/structs/parsed.rs
+++ b/msixvc/src/models/gpt/structs/parsed.rs
@@ -1,0 +1,179 @@
+use super::raw;
+
+use std::range::RangeInclusive;
+
+use uuid::Uuid;
+use zerocopy::IntoBytes;
+
+/// GPT Partition Table Header.
+#[derive(Debug, Clone, Copy)]
+pub struct GptHeader {
+    /// Revision number of header.
+    pub revision_number: u32,
+    /// Current LBA (location of this header copy).
+    pub current_lba: u64,
+    /// Backup LBA (location of the other header copy).
+    pub backup_lba: u64,
+    /// Usable LBA range for partitions (`start` = primary partition table's last LBA + 1,
+    /// `last` = secondary partition table's first LBA − 1, inclusive).
+    pub partitions_lba: RangeInclusive<u64>,
+    /// Disk GUID in little endian.
+    pub disk_guid: Uuid,
+    /// Starting LBA of array of partition entries.
+    pub partition_table_lba: u64,
+    /// Number of partition entries in array.
+    pub partition_entries_num: usize,
+    /// Size of a single partition entry (usually 80h or 128).
+    pub partition_entry_size: usize,
+    /// CRC-32 of partition entries array in little endian.
+    pub partition_table_checksum: u32,
+}
+
+impl GptHeader {
+    const MAGIC: [u8; 8] = *b"EFI PART";
+    // Technically the header size can be higher, but this way the checksum can be
+    // computed over a fixed-size struct.
+    const EXPECTED_HEADER_SIZE: u32 = GptHeader::RAW_SIZE as u32;
+    // The partition table must start at LBA 2 at the earliest: LBA 0 is reserved,
+    // and LBA 1 is where the GPT header lives.
+    const MIN_PARTITION_TABLE_LBA: u64 = 2;
+    // The GPT spec defines that the partition table must exist, so the minimum number
+    // of partition entries is 1. Also, to avoid OOM when reading malformed data, set
+    // a reasonable maximum to the number of partition entries.
+    const PARTITION_ENTRIES_NUM_RANGE: RangeInclusive<u32> = RangeInclusive {
+        start: 1,
+        last: 128,
+    };
+    /// In practice always 128 bytes, but the spec allows larger. The upper bound here is
+    /// just a reasonable maximum, not a spec requirement.
+    const PARTITION_ENTRY_SIZE_RANGE: RangeInclusive<u32> = RangeInclusive {
+        start: PartitionEntry::RAW_SIZE as u32,
+        last: 512,
+    };
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum GptHeaderParseError {
+    #[error(r#"invalid magic: expected {magic:?}, got {0:?}"#, magic = GptHeader::MAGIC)]
+    InvalidMagic([u8; 8]),
+
+    #[error(r#"invalid header size: expected {size:?}, got {0:?}"#, size = GptHeader::EXPECTED_HEADER_SIZE)]
+    InvalidHeaderSize(u32),
+
+    #[error(r#"invalid crc32 checksum: computed {computed:x}, but header stores {stored:x}"#)]
+    InvalidChecksum { computed: u32, stored: u32 },
+
+    #[error("invalid starting LBA of array of partition table: expected at least {min}, got {0}", min = GptHeader::MIN_PARTITION_TABLE_LBA)]
+    PartitionTableLbaTooShort(u64),
+
+    #[error("invalid partition entries number: expected in range {min:?}, got {0}", min = GptHeader::PARTITION_ENTRIES_NUM_RANGE)]
+    OobPartitionEntriesNum(u32),
+
+    #[error("invalid partition entry size: expected in range {min:?}, got {0}", min = GptHeader::PARTITION_ENTRY_SIZE_RANGE)]
+    OobPartitionEntrySize(u32),
+}
+
+impl TryFrom<raw::GptHeader> for GptHeader {
+    type Error = GptHeaderParseError;
+
+    fn try_from(mut value: raw::GptHeader) -> Result<Self, Self::Error> {
+        if value.magic != Self::MAGIC {
+            return Err(GptHeaderParseError::InvalidMagic(value.magic));
+        }
+
+        if value.header_size != Self::EXPECTED_HEADER_SIZE {
+            return Err(GptHeaderParseError::InvalidHeaderSize(
+                value.header_size.get(),
+            ));
+        }
+
+        // Check the CRC32 hash of the header
+        {
+            let stored = value.checksum.get();
+
+            // Clear the checksum field before hashing
+            value.checksum = 0.into();
+
+            let computed = crc32fast::hash(value.as_bytes());
+
+            if computed != stored {
+                return Err(GptHeaderParseError::InvalidChecksum { computed, stored });
+            }
+        }
+
+        if value.partition_table_lba < Self::MIN_PARTITION_TABLE_LBA {
+            return Err(GptHeaderParseError::PartitionTableLbaTooShort(
+                value.partition_table_lba.get(),
+            ));
+        }
+
+        if !Self::PARTITION_ENTRIES_NUM_RANGE.contains(&value.partition_entries_num.get()) {
+            return Err(GptHeaderParseError::OobPartitionEntriesNum(
+                value.partition_entries_num.get(),
+            ));
+        }
+
+        if !Self::PARTITION_ENTRY_SIZE_RANGE.contains(&value.partition_entry_size.get()) {
+            return Err(GptHeaderParseError::OobPartitionEntrySize(
+                value.partition_entry_size.get(),
+            ));
+        }
+
+        Ok(Self {
+            revision_number: value.revision_number.get(),
+            current_lba: value.current_lba.get(),
+            backup_lba: value.backup_lba.get(),
+            partitions_lba: RangeInclusive {
+                start: value.first_partitions_lba.get(),
+                last: value.last_partitions_lba.get(),
+            },
+            disk_guid: Uuid::from_bytes_le(value.disk_guid),
+            partition_table_lba: value.partition_table_lba.get(),
+            partition_entries_num: value.partition_entries_num.get() as usize,
+            partition_entry_size: value.partition_entry_size.get() as usize,
+            partition_table_checksum: value.partition_table_checksum.get(),
+        })
+    }
+}
+
+/// GPT Partition Table Entry.
+#[derive(Debug, Clone, Copy)]
+pub struct PartitionEntry {
+    /// Partition type GUID.
+    pub partition_type: Uuid,
+    /// Unique partition GUID.
+    pub unique_partition: Uuid,
+    /// LBA range occupied by this partition, inclusive (end is usually odd).
+    pub lba_range: RangeInclusive<u64>,
+    /// Attribute flags.
+    pub attribute_flags: u64,
+    /// Partition name (36 UTF-16LE code units).
+    pub partition_name: [u16; 0x24],
+}
+
+impl From<raw::PartitionEntry> for PartitionEntry {
+    fn from(value: raw::PartitionEntry) -> Self {
+        Self {
+            partition_type: Uuid::from_bytes_le(value.partition_type),
+            unique_partition: Uuid::from_bytes_le(value.unique_partition),
+            lba_range: RangeInclusive {
+                start: value.first_lba.get(),
+                last: value.last_lba.get(),
+            },
+            attribute_flags: value.attribute_flags.get(),
+            partition_name: value.partition_name.map(|n| n.get()),
+        }
+    }
+}
+
+impl PartitionEntry {
+    pub fn partition_name(&self) -> String {
+        let len = self
+            .partition_name
+            .iter()
+            .position(|&c| c == 0)
+            .unwrap_or(self.partition_name.len());
+
+        String::from_utf16_lossy(&self.partition_name[..len])
+    }
+}

--- a/msixvc/src/models/gpt/structs/raw.rs
+++ b/msixvc/src/models/gpt/structs/raw.rs
@@ -1,0 +1,37 @@
+use zerocopy::{FromBytes, Immutable, IntoBytes, little_endian::*};
+
+/// GPT Partition Table Header.
+///
+/// See <https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_table_header_(LBA_1)>.
+#[derive(FromBytes, IntoBytes, Immutable, Debug)]
+#[repr(C, packed)]
+pub struct GptHeader {
+    pub magic: [u8; 8],
+    pub revision_number: U32,
+    pub header_size: U32,
+    pub checksum: U32,
+    pub _reserved: U32,
+    pub current_lba: U64,
+    pub backup_lba: U64,
+    pub first_partitions_lba: U64,
+    pub last_partitions_lba: U64,
+    pub disk_guid: [u8; 16],
+    pub partition_table_lba: U64,
+    pub partition_entries_num: U32,
+    pub partition_entry_size: U32,
+    pub partition_table_checksum: U32,
+}
+
+/// GPT Partition Table Entry.
+///
+/// See <https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_entries_(LBA_2%E2%80%9333)>.
+#[derive(FromBytes, IntoBytes, Immutable, Debug)]
+#[repr(C, packed)]
+pub struct PartitionEntry {
+    pub partition_type: [u8; 16],
+    pub unique_partition: [u8; 16],
+    pub first_lba: U64,
+    pub last_lba: U64,
+    pub attribute_flags: U64,
+    pub partition_name: [U16; 0x24],
+}

--- a/msixvc/src/xvd.rs
+++ b/msixvc/src/xvd.rs
@@ -970,52 +970,27 @@ impl XvdFile {
     }
 }
 
-pub fn unpack_file(
+pub async fn unpack_file(
     xvd: XvdFile,
     path: String,
     destination: String,
     full_key: [u8; 32],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let sfile = std::fs::File::open(path)?;
-    let block_size = 4096; //xvd.header.block_size;
-    let gp = gpt::GptConfig::new()
-        .writable(false)
-        .logical_block_size(if block_size == 512 {
-            gpt::disk::LogicalBlockSize::Lb512
-        } else if block_size == 4096 {
-            gpt::disk::LogicalBlockSize::Lb4096
-        } else {
-            todo!("unsupported block_size: {}", block_size)
-        })
-        .open_from_device(XvdStream {
-            inner: sfile.try_clone().unwrap(),
-            offset: xvd.drive_data_offset,
-            end_offset: xvd.drive_data_offset + xvd.header.drive_size,
-            encryption_info: None,
-        })
-        .unwrap();
+    use tokio::io::AsyncSeekExt;
 
-    let mut ntfs_partition = None;
-    for (index, part) in gp.partitions() {
-        if !part.is_used() {
-            continue;
-        }
+    let mut file = tokio::fs::File::open(path).await?;
+    file.seek(std::io::SeekFrom::Start(xvd.drive_data_offset))
+        .await?;
 
-        let part_start = part.bytes_start(*gp.logical_block_size()).unwrap();
-        let part_len = part.bytes_len(*gp.logical_block_size()).unwrap();
+    let data_part =
+        crate::gpt::goto_windows_basic_data_partition(&mut file, xvd.header.volume_flags).await?;
 
-        if ntfs_partition.is_none() {
-            ntfs_partition = Some((index, part.name.clone(), part_start, part_len));
-        }
-    }
-
-    let (_, _, part_start, part_len) = ntfs_partition.expect("no used GPT partition found");
-    let partition_offset = xvd.drive_data_offset + part_start;
+    println!("{data_part:?}");
 
     let mut fs = XvdStream {
-        inner: sfile.try_clone().unwrap(),
-        offset: partition_offset,
-        end_offset: partition_offset + part_len,
+        inner: file.into_std().await,
+        offset: xvd.drive_data_offset + data_part.start,
+        end_offset: xvd.drive_data_offset + data_part.end,
         encryption_info: Some(XvdEncryptionInfo {
             full_key,
             encrypted_sections: xvd.encrypted_section_infos,

--- a/xodus-cli/src/commands/extract.rs
+++ b/xodus-cli/src/commands/extract.rs
@@ -26,6 +26,8 @@ pub async fn run(
     }
     if let Some((_, content_key)) = game_splicense.content_keys.into_iter().next() {
         let unpacked = content_key.unpack(&key).expect("failed to unpack");
-        unpack_file(xvd, path.to_string(), destination.to_string(), *unpacked).expect("unpack ok");
+        unpack_file(xvd, path.to_string(), destination.to_string(), *unpacked)
+            .await
+            .expect("unpack ok");
     }
 }


### PR DESCRIPTION
Replace the parse of the GPT partition table with our own implementation, which is Async and does not require Seek (useful for streaming, as it avoids network requests). The idea would be to replace the NTFS partition parsing, too, but that is a lot more complex.

I'm pushing this as a proof of concept, as I don't really like how it turned out. It feels fragile to me: I intended to do a very simple parsing knowing how the partition tables of XVCs are laid out in practice, but ended up making it too complex, capable of parsing any valid GPT partition table. Still, it doesn't cover every possible invalid header, which makes this implementation an odd middle point between simple parsing and complete/robust parsing.

It works, though.