### PR TITLE
refactor: apply clippy suggestions

### DIFF
--- a/msixvc/src/streaming.rs
+++ b/msixvc/src/streaming.rs
@@ -71,6 +71,10 @@ impl<'t> HttpRead<'t> {
         self.len
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
     fn begin_open_stream(&mut self, start: u64) {
         let client = self.client.clone();
         let url = self.url.clone();
@@ -263,6 +267,10 @@ where
 
     pub fn len(&self) -> u64 {
         self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     pub fn cached_len(&self) -> u64 {

--- a/msixvc/src/xvd.rs
+++ b/msixvc/src/xvd.rs
@@ -65,6 +65,10 @@ impl<R> SyncSubstream<R> {
         self.len
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
     pub fn into_inner(self) -> R {
         self.inner
     }
@@ -880,10 +884,10 @@ impl XvdFile {
             if page_in_section >= page_start + page_count || remaining == 0 {
                 break;
             }
-            let next = if stream.is_none() {
-                Ok(None)
+            let next = if let Some(s) = stream.as_mut() {
+                timeout(stall_timeout, s.next()).await
             } else {
-                timeout(stall_timeout, stream.as_mut().unwrap().next()).await
+                Ok(None)
             };
             let data: Bytes;
             if let Ok(Some(Ok(b))) = next {

--- a/xodus-cli/src/commands/login.rs
+++ b/xodus-cli/src/commands/login.rs
@@ -21,7 +21,7 @@ pub async fn run(client: &reqwest::Client, tokens: &TokenManager) {
         Some(soap::BodyContent::RequestSecurityTokenResponseCollection(collection)) => {
             collection.security_tokens
         }
-        Some(soap::BodyContent::RequestSecurityTokenResponse(token)) => vec![token],
+        Some(soap::BodyContent::RequestSecurityTokenResponse(token)) => vec![*token],
         None => {
             eprintln!("Didn't log in");
             vec![]

--- a/xodus-cli/src/license.rs
+++ b/xodus-cli/src/license.rs
@@ -63,7 +63,7 @@ pub async fn get_license(
         }
         ExchangeUserTokenOutcome::Issued(soap::BodyContent::RequestSecurityTokenResponse(
             token,
-        )) => token.into(),
+        )) => (*token).into(),
         _ => unreachable!("Only responses are handled"),
     };
     let Token::Compact(user_token) = user_token else {

--- a/xodus/src/api/live/mod.rs
+++ b/xodus/src/api/live/mod.rs
@@ -38,7 +38,7 @@ pub async fn authenticate_device(
 ) -> Result<soap::Envelope, rst::RSTError> {
     let request = rst::RSTRequestBuilder::new()
         .username(soap::UsernameToken::devicetoken(username))
-        .signature(rst::RSTSignature::RSA(private_key))
+        .signature(rst::RSTSignature::Rsa(Box::new(private_key)))
         .scope_policy("http://Passport.NET/tb", None)
         .build()?;
 
@@ -61,17 +61,17 @@ pub async fn exchange_device_token(
         .sso_flags("SsoRestr")
         .hosting_app(&hosting_app)
         .device_token(token)
-        .signature(rst::RSTSignature::HMAC {
+        .signature(rst::RSTSignature::Hmac {
             clep_secret: &*hmac_secret,
             tpm_secret: &[],
         })
         .scope_policy(&scope, policy)
         .build()?;
 
-    let envelope = request.request(&client).await?;
+    let envelope = request.request(client).await?;
 
     match envelope.body.body {
-        soap::BodyContent::RequestSecurityTokenResponse(res) => Ok(res),
+        soap::BodyContent::RequestSecurityTokenResponse(res) => Ok(*res),
         soap::BodyContent::RequestSecurityTokenResponseCollection(mut collection) => {
             let token = collection.security_tokens.remove(0);
             Ok(token)
@@ -80,6 +80,9 @@ pub async fn exchange_device_token(
     }
 }
 
+// Each parameter maps directly to a distinct SOAP request field; grouping them
+// into a params struct would just move the sprawl rather than reduce it.
+#[allow(clippy::too_many_arguments)]
 pub async fn exchange_user_token(
     client: &reqwest::Client,
     user_token: LegacyToken,
@@ -102,7 +105,7 @@ pub async fn exchange_user_token(
         .hosting_app(&hosting_app)
         .sso_flags("SsoRestr")
         .license_signature_key_version(None)
-        .signature(rst::RSTSignature::HMAC {
+        .signature(rst::RSTSignature::Hmac {
             clep_secret: &*hmac_secret,
             tpm_secret: &[],
         });

--- a/xodus/src/api/live/rst/builder.rs
+++ b/xodus/src/api/live/rst/builder.rs
@@ -41,46 +41,40 @@ impl<'a> RSTRequestBuilder<'a> {
     }
 
     pub fn inline_ux(mut self, inline_ux: &'a str) -> Self {
-        self.header
-            .auth_info
-            .as_mut()
-            .map(|a| a.inline_ux = inline_ux.to_string());
+        if let Some(a) = self.header.auth_info.as_mut() {
+            a.inline_ux = inline_ux.to_string();
+        }
         self
     }
 
     pub fn inline_ft(mut self, inline_ft: &'a str) -> Self {
-        self.header
-            .auth_info
-            .as_mut()
-            .map(|a| a.inline_ft = Some(inline_ft.to_string()));
+        if let Some(a) = self.header.auth_info.as_mut() {
+            a.inline_ft = Some(inline_ft.to_string());
+        }
         self
     }
 
     pub fn license_signature_key_version(mut self, version: Option<&'a str>) -> Self {
-        self.header
-            .auth_info
-            .as_mut()
-            .map(|a| a.license_signature_key_version = version.map(str::to_string));
+        if let Some(a) = self.header.auth_info.as_mut() {
+            a.license_signature_key_version = version.map(str::to_string);
+        }
         self
     }
 
     pub fn hosting_app(mut self, hosting_app: &'a str) -> Self {
-        self.header
-            .auth_info
-            .as_mut()
-            .map(|a| a.hosting_app = hosting_app.to_string());
+        if let Some(a) = self.header.auth_info.as_mut() {
+            a.hosting_app = hosting_app.to_string();
+        }
         self
     }
 
     pub fn sso_flags(mut self, sso_flags: &'a str) -> Self {
-        self.header
-            .auth_info
-            .as_mut()
-            .map(|a| a.sso_flags = sso_flags.to_string());
+        if let Some(a) = self.header.auth_info.as_mut() {
+            a.sso_flags = sso_flags.to_string();
+        }
         self
     }
 
-    #[must_use]
     pub fn scope_policy(
         mut self,
         scope: &'a str,
@@ -100,7 +94,6 @@ impl<'a> RSTRequestBuilder<'a> {
         self
     }
 
-    #[must_use]
     pub fn build(mut self) -> Result<RSTRequest<'a>, RSTBuilderError> {
         let mut security_tokens = self.build_request_security_tokens();
 
@@ -186,7 +179,7 @@ impl<'a> RSTRequestBuilder<'a> {
                 digest_method: soap::AlgorithmNode {
                     algorithm: XML_SIGNATURE_DIGEST_SHA256.to_string(),
                 },
-                digest_value: "".to_string(),
+                digest_value: String::new(),
                 transforms: soap::SignatureTransforms {
                     transform: vec![soap::AlgorithmNode {
                         algorithm: XML_SIGNATURE_TRANSFORM_EXCLUSIVE.to_string(),
@@ -222,7 +215,7 @@ impl<'a> RSTRequestBuilder<'a> {
         Some(soap::Signature {
             xmlns: soap::XML_SIGNATURE_NS.to_string(),
             signed_info,
-            key_info: key_info,
+            key_info,
             signature_value: String::default(),
         })
     }

--- a/xodus/src/api/live/rst/request.rs
+++ b/xodus/src/api/live/rst/request.rs
@@ -71,7 +71,11 @@ fn verify_and_decrypt_envelope<'a>(
         && let Some(enc_pp) = envelope.header.encrypted_pp.take()
     {
         log::trace!("Decrypting soap::PP");
-        let pp = utils::decrypt_soap_encrypted_data(enc_pp.encrypted_data, &signature, &nonces)?;
+        let pp = utils::decrypt_soap_encrypted_data(
+            Box::new(enc_pp.encrypted_data),
+            &signature,
+            &nonces,
+        )?;
         envelope.header.pp = pp;
     }
 

--- a/xodus/src/api/live/rst/signature.rs
+++ b/xodus/src/api/live/rst/signature.rs
@@ -5,8 +5,8 @@ use crate::{
 use base64::prelude::*;
 
 pub enum RSTSignature<'a> {
-    RSA(rsa::RsaPrivateKey),
-    HMAC {
+    Rsa(Box<rsa::RsaPrivateKey>),
+    Hmac {
         clep_secret: &'a [u8],
         /// Used only if TPMInfo public key was sent.
         /// Right now it's not needed, but the builder is capable of signing with it
@@ -17,21 +17,21 @@ pub enum RSTSignature<'a> {
 impl<'a> RSTSignature<'a> {
     pub fn method(&self) -> &'static str {
         match self {
-            RSTSignature::HMAC { .. } => XML_SIGNATURE_METHOD_HMAC,
-            RSTSignature::RSA(_) => XML_SIGNATURE_METHOD_RSA,
+            RSTSignature::Hmac { .. } => XML_SIGNATURE_METHOD_HMAC,
+            RSTSignature::Rsa(_) => XML_SIGNATURE_METHOD_RSA,
         }
     }
 
     pub fn key_info(&self) -> Option<soap::SignatureKeyInfo> {
         match self {
-            RSTSignature::HMAC { .. } => Some(soap::SignatureKeyInfo {
+            RSTSignature::Hmac { .. } => Some(soap::SignatureKeyInfo {
                 security_token_reference: soap::SecurityTokenReference {
                     reference: soap::ReferenceUri {
                         uri: "#SignKey".to_string(),
                     },
                 },
             }),
-            RSTSignature::RSA(_) => None,
+            RSTSignature::Rsa(_) => None,
         }
     }
 
@@ -41,7 +41,7 @@ impl<'a> RSTSignature<'a> {
         reference_uri: &str,
     ) -> Option<soap::DerivedKeyToken> {
         match self {
-            RSTSignature::HMAC { .. } => Some(soap::DerivedKeyToken {
+            RSTSignature::Hmac { .. } => Some(soap::DerivedKeyToken {
                 nonce: BASE64_STANDARD.encode(nonce),
                 id: "SignKey".to_string(),
                 algorithm: "urn:liveid:SP800108_CTR_HMAC_SHA256_DOUBLEDERIVED".to_string(),
@@ -54,12 +54,12 @@ impl<'a> RSTSignature<'a> {
                     reference: soap::ReferenceUri { uri: reference_uri.to_string() },
                 }),
             }),
-            RSTSignature::RSA(_) => None,
+            RSTSignature::Rsa(_) => None,
         }
     }
 
     pub fn hmac_key(&self, nonce: &[u8]) -> Option<[u8; 32]> {
-        if let Self::HMAC {
+        if let Self::Hmac {
             clep_secret,
             tpm_secret,
         } = self
@@ -79,7 +79,7 @@ impl<'a> RSTSignature<'a> {
 
     pub fn signing_key(&self, nonce: &[u8]) -> bergshamra::KeyData {
         match self {
-            RSTSignature::HMAC {
+            RSTSignature::Hmac {
                 clep_secret,
                 tpm_secret,
             } => {
@@ -93,10 +93,10 @@ impl<'a> RSTSignature<'a> {
 
                 bergshamra::KeyData::Hmac(hmac_key.to_vec())
             }
-            RSTSignature::RSA(private_key) => {
-                let public_key = rsa::RsaPublicKey::from(private_key);
+            RSTSignature::Rsa(private_key) => {
+                let public_key = rsa::RsaPublicKey::from(private_key.as_ref());
                 bergshamra::KeyData::Rsa {
-                    private: Some(private_key.clone()),
+                    private: Some(private_key.as_ref().clone()),
                     public: public_key,
                 }
             }

--- a/xodus/src/api/live/utils.rs
+++ b/xodus/src/api/live/utils.rs
@@ -95,7 +95,7 @@ pub fn sign_xml(
 }
 
 pub fn decrypt_soap_encrypted_data<T: serde::de::DeserializeOwned>(
-    encrypted_data: soap::EncryptedData,
+    encrypted_data: Box<soap::EncryptedData>,
     signature: &rst::RSTSignature,
     nonces: &HashMap<String, String>,
 ) -> Result<T, rst::RSTError> {

--- a/xodus/src/api/xbox/mod.rs
+++ b/xodus/src/api/xbox/mod.rs
@@ -44,7 +44,7 @@ pub async fn run(
         }
         ExchangeUserTokenOutcome::Issued(soap::BodyContent::RequestSecurityTokenResponse(
             token,
-        )) => token.into(),
+        )) => (*token).into(),
         _ => unreachable!("Only responses are handled"),
     };
     let Token::Compact(user_token) = user_token else {

--- a/xodus/src/auth.rs
+++ b/xodus/src/auth.rs
@@ -111,7 +111,7 @@ pub async fn do_sisu(
     };
 
     let user_token = crate::api::live::exchange_user_token(
-        &client,
+        client,
         token,
         "USERNAME".to_string(),
         device_token,
@@ -120,7 +120,7 @@ pub async fn do_sisu(
         client_id.to_string(),
         &[
             (
-                format!("scope={scope}&api-version=2.0&clientid={}", client_id),
+                format!("scope={scope}&api-version=2.0&clientid={client_id}"),
                 Some(soap::PolicyReference::token_broker()),
             ),
             ("http://Passport.NET/tb".to_string(), None),
@@ -162,7 +162,7 @@ pub async fn do_sisu(
     let mut auth = XalAuthenticator::new(
         XalAppParameters {
             client_id: client_id.to_owned(),
-            title_id: Some(format!("{}", title_id)),
+            title_id: Some(title_id.to_string()),
             auth_scopes: vec![],
             redirect_uri: None,
             client_secret: None,
@@ -171,7 +171,7 @@ pub async fn do_sisu(
             user_agent: "XAL GRTS 2025.11.20251105.000".to_string(),
             device_type: DeviceType::WIN32,
             client_version: "10.0.22621".to_string(),
-            query_display: "".to_string(),
+            query_display: String::new(),
         },
         "RETAIL".to_owned(),
     );

--- a/xodus/src/licensing/splicense.rs
+++ b/xodus/src/licensing/splicense.rs
@@ -175,7 +175,7 @@ fn decrypt_cbc_zero_iv<const N: usize>(key_schedule: [u32; 58], data: &[u8; N]) 
     let mut prev: u128 = 0;
     let data_chunks = data.as_chunks::<16>().0;
     let output_chunks = out.as_chunks_mut::<16>().0;
-    for (chunk_in, chunk_out) in data_chunks.into_iter().zip(output_chunks) {
+    for (chunk_in, chunk_out) in data_chunks.iter().zip(output_chunks) {
         let block: [u8; 16] = *chunk_in;
         let next = u128::from_le_bytes(block);
 

--- a/xodus/src/models/soap/crypto.rs
+++ b/xodus/src/models/soap/crypto.rs
@@ -47,6 +47,7 @@ pub struct SignatureKeyInfo {
 }
 
 impl SignatureKeyInfo {
+    #[must_use]
     pub fn sign_key() -> Self {
         Self {
             security_token_reference: SecurityTokenReference {

--- a/xodus/src/models/soap/envelope.rs
+++ b/xodus/src/models/soap/envelope.rs
@@ -84,6 +84,12 @@ pub struct Header {
     pub pp: Option<PP>,
 }
 
+impl Default for Header {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Header {
     pub fn new() -> Self {
         let now = chrono::Utc::now();
@@ -131,7 +137,7 @@ pub enum BodyContent {
     RequestMultipleSecurityTokens(RequestMultipleSecurityTokens),
 
     RequestSecurityTokenResponseCollection(RequestSecurityTokenResponseCollection),
-    RequestSecurityTokenResponse(RequestSecurityTokenResponse),
-    EncryptedData(EncryptedData),
+    RequestSecurityTokenResponse(Box<RequestSecurityTokenResponse>),
+    EncryptedData(Box<EncryptedData>),
     Fault(Fault),
 }

--- a/xodus/src/models/soap/security.rs
+++ b/xodus/src/models/soap/security.rs
@@ -45,7 +45,7 @@ pub struct AuthInfo {
 impl Default for AuthInfo {
     fn default() -> Self {
         Self {
-            sso_flags: "".to_string(),
+            sso_flags: String::new(),
             ps: "http://schemas.microsoft.com/Passport/SoapServices/PPCRL".to_owned(),
             id: "PPAuthInfo".to_owned(),
             hosting_app: "{DF60E2DF-88AD-4526-AE21-83D130EF0F68}".to_owned(),

--- a/xodus/src/tokens/device.rs
+++ b/xodus/src/tokens/device.rs
@@ -74,7 +74,7 @@ async fn reauthenticate_device(client: &reqwest::Client, tokens: &TokenManager, 
 
 fn save_device_sts_token(
     tokens: &TokenManager,
-    resp: crate::models::soap::RequestSecurityTokenResponse,
+    resp: Box<crate::models::soap::RequestSecurityTokenResponse>,
 ) {
     let key_name = resp
         .requested_security_token
@@ -86,7 +86,7 @@ fn save_device_sts_token(
         .as_ref()
         .unwrap()
         .clone();
-    let token = resp.into();
+    let token = (*resp).into();
     tokens
         .save_device_token(key_name, token)
         .expect("Failed to save device token");


### PR DESCRIPTION
- enum naming convention
- use box in enum to avoid size inflation
- prefer String::new() instead of "".to_string()
- use as_mut when modifying header Option type in RSTRequestBuilder

additionally I added a few fixes from pedantic ruleset