### PR TITLE
fix: return the device token do_sisu was authorized with

### DIFF
--- a/crates/xodus/src/auth.rs
+++ b/crates/xodus/src/auth.rs
@@ -77,6 +77,7 @@ pub async fn do_sisu(
     (
         XalAuthenticator,
         xal::response::SisuRPSAuthorizationResponse,
+        xal::response::DeviceToken,
     ),
     Box<dyn std::error::Error>,
 > {
@@ -183,7 +184,7 @@ pub async fn do_sisu(
         .sisu_authorize_rps(&user_token, &data.token, None)
         .await
         .expect("ok");
-    Ok((auth, resp))
+    Ok((auth, resp, data))
 }
 
 #[ignore]
@@ -193,7 +194,7 @@ async fn test_minecraft_win_auth() {
     crate::secrets::init_secrets().expect("Unable to initialize credentials");
     let tokens = TokenManager::with_keychain_and_memory();
 
-    let (_, resp) = do_sisu(&client, &tokens, "0000000040159362", 896928775)
+    let (_, resp, _) = do_sisu(&client, &tokens, "0000000040159362", 896928775)
         .await
         .expect("ok");
 


### PR DESCRIPTION
`do_sisu` mints a device token via `get_device_token_rps` and then drops it. The title token SISU returns is bound to that device, so a caller that wants an XSTS from the SISU bundle has no way to supply a matching device token - minting a fresh one via `get_device_token()` uses `XalAuthenticator::device_id = Uuid::new_v4()`, a different machine every instance, and `xsts.auth` rejects the pair with `401 XSTS error="title_usage_by_device_exceeded"` (XErr 2148916254).

Return it as a third tuple element so the device token, the title token bound to it, and the user token can all describe one device.