### PR TITLE
feat: mint title-claimed XSTS tokens over IPC

### DIFF
--- a/crates/xodus-service/src/connection/xml.rs
+++ b/crates/xodus-service/src/connection/xml.rs
@@ -4,7 +4,9 @@ use xodus::{
         live::ExchangeUserTokenOutcome,
         secrets::Token,
         soap,
-        xgameruntime::xuser::{MSATokenRequest, MSATokenResponse},
+        xgameruntime::xuser::{
+            MSATokenRequest, MSATokenResponse, XstsTokenRequest, XstsTokenResponse,
+        },
     },
     proto::xodus::XodusMessageType,
 };
@@ -43,6 +45,61 @@ pub async fn parse_message(
 ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
     match message_type {
         XodusMessageType::Ping => Ok(buffer),
+        // An XSTS carrying the TITLE claim, for one relying party.
+        //
+        // This is minted here rather than by the caller because the three tokens
+        // involved must all describe ONE device: the device token, the SISU title
+        // token bound to it, and the user token. Pairing a title token with a
+        // device token minted separately is rejected by xsts.auth with
+        // `401 XSTS error="title_usage_by_device_exceeded"`, and only this side
+        // holds the device identity, so only this side can keep them consistent.
+        XodusMessageType::XstsTokenRequest => {
+            let req = quick_xml::de::from_str::<XstsTokenRequest>(std::str::from_utf8(&buffer)?)?;
+            let title_id: i64 = req.title_id.parse().unwrap_or(0);
+            log::debug!(
+                "XSTS request: rp={} client={} title={}",
+                req.relying_party,
+                req.client_id,
+                title_id
+            );
+
+            // do_sisu returns the device token it was authorized with - use THAT.
+            let (mut auth, sisu, device) =
+                xodus::auth::do_sisu(&context.client, context.tokens(), &req.client_id, title_id)
+                    .await
+                    // do_sisu's error is a bare Box<dyn Error>; this handler must
+                    // return one that is Send + Sync, so carry the text across.
+                    .map_err(|e| std::io::Error::other(format!("sisu failed: {e}")))?;
+            let xsts = auth
+                .get_xsts_token(
+                    Some(&device),
+                    Some(&sisu.title_token),
+                    Some(&sisu.user_token),
+                    &req.relying_party,
+                )
+                .await?;
+            let expiry = xsts.not_after.timestamp();
+            log::debug!(
+                "XSTS issued for {}: uhs {} ({} chars)",
+                req.relying_party,
+                xsts.userhash(),
+                xsts.token.len()
+            );
+            let xuid = xsts
+                .display_claims
+                .as_ref()
+                .and_then(|c| c.xui.first())
+                .and_then(|x| x.get("xid"))
+                .cloned()
+                .unwrap_or_default();
+            let payload = XstsTokenResponse {
+                user_hash: xsts.userhash(),
+                xuid,
+                token: xsts.token,
+                expiry,
+            };
+            Ok(quick_xml::se::to_string(&payload)?.as_bytes().to_vec())
+        }
         XodusMessageType::MsaTokenRequest => {
             log::debug!("Raw buffer: {buffer:?}");
             let string_buf = std::str::from_utf8(&buffer)?;

--- a/crates/xodus/proto/xodus/common.proto
+++ b/crates/xodus/proto/xodus/common.proto
@@ -8,4 +8,10 @@ enum XodusMessageType {
     PONG = 2;
     MSA_TOKEN_REQUEST=3;
     MSA_TOKEN_RESPONSE=4;
+    // An XSTS token for a specific relying party, minted from a SISU
+    // bundle so it carries the TITLE claim. The title claim is what
+    // gameservices.fm.forzamotorsport.net requires; without it the Logon
+    // is refused with a blank 403.
+    XSTS_TOKEN_REQUEST=5;
+    XSTS_TOKEN_RESPONSE=6;
 }

--- a/crates/xodus/src/auth.rs
+++ b/crates/xodus/src/auth.rs
@@ -77,6 +77,7 @@ pub async fn do_sisu(
     (
         XalAuthenticator,
         xal::response::SisuRPSAuthorizationResponse,
+        xal::response::DeviceToken,
     ),
     Box<dyn std::error::Error>,
 > {
@@ -183,7 +184,7 @@ pub async fn do_sisu(
         .sisu_authorize_rps(&user_token, &data.token, None)
         .await
         .expect("ok");
-    Ok((auth, resp))
+    Ok((auth, resp, data))
 }
 
 #[ignore]
@@ -193,7 +194,7 @@ async fn test_minecraft_win_auth() {
     crate::secrets::init_secrets().expect("Unable to initialize credentials");
     let tokens = TokenManager::with_keychain_and_memory();
 
-    let (_, resp) = do_sisu(&client, &tokens, "0000000040159362", 896928775)
+    let (_, resp, _) = do_sisu(&client, &tokens, "0000000040159362", 896928775)
         .await
         .expect("ok");
 

--- a/crates/xodus/src/models/xgameruntime/xuser.rs
+++ b/crates/xodus/src/models/xgameruntime/xuser.rs
@@ -18,3 +18,32 @@ pub struct MSATokenResponse {
     pub device_rps: String,
     pub device_expiry: i64,
 }
+
+/// Request an XSTS token that carries a TITLE claim, for one relying party.
+///
+/// The caller supplies its own identity because only it knows them: the GDK
+/// reads MSAAppId and TitleId out of MicrosoftGame.config.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct XstsTokenRequest {
+    pub relying_party: String,
+    pub client_id: String,
+    /// Decimal. MicrosoftGame.config stores TitleId in hex, so the caller
+    /// converts; keeping it a string avoids a second XML integer convention.
+    pub title_id: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct XstsTokenResponse {
+    pub token: String,
+    /// The `x=` half of `XBL3.0 x=<uhs>;<token>`; it is per-token, so returning
+    /// it here saves the caller parsing display claims it cannot see.
+    pub user_hash: String,
+    /// The XUID from the same display claims. The caller sets its user id from
+    /// this: the local XSTS path reads `xid` out of the response itself, so a
+    /// token minted here must hand it back or the user id silently stays 0 -
+    /// which shows up as requests for `users/xuid(0)/...` being refused 403.
+    pub xuid: String,
+    pub expiry: i64,
+}


### PR DESCRIPTION
Adds XSTS_TOKEN_REQUEST/RESPONSE (5/6) and a handler that runs SISU for the caller's client id and title id, then exchanges the bundle for an XSTS scoped to one relying party.

A caller cannot do this itself. The device token, the SISU title token bound to it, and the user token must all describe one device, and only this side holds the device identity - so only this side can keep the three consistent. The observable difference is the userhash: a token carrying a TITLE claim gets a different uhs per relying party, while a token minted from a user token alone gets one uniform uhs everywhere.

The response carries the uhs and the XUID alongside the token. The uhs is the `x=` half of `XBL3.0 x=<uhs>;<token>` and is per-token. The XUID is needed because callers that mint locally read `xid` out of their own XSTS response; a token minted here must hand it back, or the caller's user id silently stays 0 and its requests go out as `users/xuid(0)/...` and are refused.