### PR TITLE
feat: key-chain-file for development

### DIFF
--- a/crates/xodus/Cargo.toml
+++ b/crates/xodus/Cargo.toml
@@ -49,3 +49,6 @@ ed25519-dalek = "2.2.0"
 
 [build-dependencies]
 prost-build = "0.14.4"
+
+[features]
+key-chain-file = []

--- a/crates/xodus/src/secrets.rs
+++ b/crates/xodus/src/secrets.rs
@@ -1,22 +1,35 @@
 pub static SERVICE_NAME: &str = "Xodus Service";
 
 pub fn init_secrets() -> Result<(), keyring_core::Error> {
-    #[cfg(target_os = "linux")]
+    #[cfg(feature = "key-chain-file")]
     {
-        keyring_core::set_default_store(dbus_secret_service_keyring_store::Store::new()?);
-    }
-
-    #[cfg(target_os = "macos")]
-    {
-        keyring_core::set_default_store(apple_native_keyring_store::keychain::Store::new()?);
-    }
-
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    {
-        let store = keyring_core::sample::Store::new_with_configuration(
-            &std::collections::HashMap::from([("persist", "true")]),
+        let store = keyring_core::sample::Store::new_with_backing(
+            secrets_backing_file()
+                .to_str()
+                .expect("Invalid secrets backing path"),
         )?;
         keyring_core::set_default_store(store);
+    }
+
+    #[cfg(not(feature = "key-chain-file"))]
+    {
+        #[cfg(target_os = "linux")]
+        {
+            keyring_core::set_default_store(dbus_secret_service_keyring_store::Store::new()?);
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            keyring_core::set_default_store(apple_native_keyring_store::keychain::Store::new()?);
+        }
+
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            let store = keyring_core::sample::Store::new_with_configuration(
+                &std::collections::HashMap::from([("persist", "true")]),
+            )?;
+            keyring_core::set_default_store(store);
+        }
     }
 
     Ok(())
@@ -28,4 +41,13 @@ pub fn get_entry(user: &str) -> Result<keyring_core::Entry, keyring_core::Error>
 
 pub fn destroy_secrets() {
     keyring_core::unset_default_store();
+}
+
+#[cfg(feature = "key-chain-file")]
+fn secrets_backing_file() -> std::path::PathBuf {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir)
+        .join(".xodus-keyring.ron")
 }


### PR DESCRIPTION
* for testing purposes e.g. avoid keypass prompt on mac on rebuild
* cargo build --features key-chain-file
* allow share login between os and wine etc.
