### PR TITLE
fix(cli): pick default run executable deterministically

### DIFF
--- a/crates/xodus-cli/src/commands/run.rs
+++ b/crates/xodus-cli/src/commands/run.rs
@@ -214,16 +214,10 @@ pub async fn run(
 
     // HashMap iteration order is randomized per-process, so picking "the first
     // entry seen" as the default executable (when `--exe` isn't given) is
-    // undeterministic and can land on a non-.exe file. Pick deterministically
-    // instead, restricted to actual .exe candidates.
+    // undeterministic. Pick deterministically instead.
     let default_exe = exe
         .is_none()
-        .then(|| {
-            fds.iter()
-                .map(|(name, _)| *name)
-                .filter(|name| name.to_ascii_lowercase().ends_with(".exe"))
-                .min()
-        })
+        .then(|| fds.iter().map(|(name, _)| *name).min())
         .flatten();
 
     let mut nt_entry = None;

--- a/crates/xodus-cli/src/commands/run.rs
+++ b/crates/xodus-cli/src/commands/run.rs
@@ -212,6 +212,20 @@ pub async fn run(
     let nt_prefix = out_absolute.to_string_lossy().replace("/", "\\");
     let nt_prefix = nt_prefix.trim_end_matches('\\');
 
+    // HashMap iteration order is randomized per-process, so picking "the first
+    // entry seen" as the default executable (when `--exe` isn't given) is
+    // undeterministic and can land on a non-.exe file. Pick deterministically
+    // instead, restricted to actual .exe candidates.
+    let default_exe = exe
+        .is_none()
+        .then(|| {
+            fds.iter()
+                .map(|(name, _)| *name)
+                .filter(|name| name.to_ascii_lowercase().ends_with(".exe"))
+                .min()
+        })
+        .flatten();
+
     let mut nt_entry = None;
 
     for fd in fds {
@@ -225,7 +239,7 @@ pub async fn run(
             if exe == fd.0 {
                 nt_entry = Some(nt_path)
             }
-        } else if nt_entry.is_none() {
+        } else if default_exe == Some(fd.0) {
             nt_entry = Some(nt_path)
         }
 


### PR DESCRIPTION
## What

`xodus-cli run` without an explicit `--exe` picked its default launch target by taking "the first entry seen" while iterating the package's `HashMap<String, SegmentFile>`. Rust's default hasher randomizes iteration order per process, so the choice was non-deterministic across runs — matching the report of different executables being picked between runs.

## Fix

Break ties deterministically by picking the lexicographically smallest name among the `keep_encrypted` candidates. All `keep_encrypted` files are still mapped into `WINE_DLL_FILE_MAP` as before — only the *default launch target* selection changed.

(Earlier revision also filtered candidates to names ending in `.exe` — dropped per @ChristopherHX's comment that `keep_encrypted` implying `.exe` is already an invariant in this codebase, so the filter added nothing.)

## Testing

cargo build --workspace, cargo test --workspace, and cargo fmt --check --all all pass. No package test fixtures exist in this repo to exercise run.rs end-to-end, so this was verified by code inspection plus a standalone reproduction of the old vs. new selection logic against a synthetic file set (confirmed non-determinism before, determinism after).

Fixes #106