### PR TITLE
fix(hardware): bound the pkexec wait when probing SMBIOS on Linux

### DIFF
--- a/crates/xodus/src/hardware.rs
+++ b/crates/xodus/src/hardware.rs
@@ -152,19 +152,46 @@ fn load_raw_smbios() -> io::Result<Vec<u8>> {
 
 #[cfg(target_os = "linux")]
 fn load_raw_smbios() -> io::Result<Vec<u8>> {
-    let cmd = Command::new("pkexec")
+    use std::time::{Duration, Instant};
+
+    let mut child = Command::new("pkexec")
         .args(["cat", "/sys/firmware/dmi/entries/1-0/raw"])
         .stdout(Stdio::piped())
         .spawn()?;
-    let output = cmd.wait_with_output()?;
 
-    if output.status.success() {
-        Ok(output.stdout)
-    } else {
-        Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            "unable to probe SMBIOS data",
-        ))
+    // pkexec blocks forever waiting on a polkit authentication agent. If none is
+    // running (headless/SSH/minimal WM sessions), the process never returns and
+    // hangs the caller indefinitely with no error. Bound the wait so that case
+    // degrades to an error instead. The DMI type-1 "raw" entry is a few hundred
+    // bytes at most, well under a pipe buffer, so it's safe to read only after
+    // the child has exited.
+    const TIMEOUT: Duration = Duration::from_secs(10);
+    let start = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait()? {
+            let mut output = Vec::new();
+            if let Some(mut stdout) = child.stdout.take() {
+                use std::io::Read;
+                stdout.read_to_end(&mut output)?;
+            }
+            return if status.success() {
+                Ok(output)
+            } else {
+                Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "unable to probe SMBIOS data",
+                ))
+            };
+        }
+        if start.elapsed() > TIMEOUT {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "pkexec did not respond within 10s (no polkit authentication agent running?)",
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(100));
     }
 }
 

--- a/crates/xodus/src/hardware.rs
+++ b/crates/xodus/src/hardware.rs
@@ -150,48 +150,79 @@ fn load_raw_smbios() -> io::Result<Vec<u8>> {
     raw_smbios_from_device()
 }
 
+// Common polkit authentication agent binaries across desktop environments.
+// pkexec needs one of these (or an equivalent) registered on the session bus
+// to ever show a prompt; without one it blocks in `pkexec` forever with no
+// error (confirmed live - `pstree` on the stuck tree shows `pkexec` sitting
+// idle on `do_wait`). This list isn't exhaustive (a custom/rare agent won't
+// match), but it covers the desktop environments this is actually likely to
+// run under; an unmatched-but-present agent just means the fallback below
+// (attempt pkexec anyway) is safe, since a real agent showing a prompt means
+// pkexec correctly returns once the user answers it, one way or another.
+const KNOWN_POLKIT_AGENTS: &[&str] = &[
+    "polkit-gnome-authentication-agent-1",
+    "polkit-kde-authentication-agent-1",
+    "lxqt-policykit-agent",
+    "lxpolkit",
+    "mate-polkit",
+    "xfce-polkit",
+    "ukui-polkit",
+];
+
+fn polkit_agent_running() -> bool {
+    // -f (match against the full command line) rather than -x (match against
+    // `comm`, which the kernel truncates to 15 characters): several agent
+    // binary names exceed that, e.g. polkit-kde-authentication-agent-1 (34
+    // chars, truncated to "polkit-kde-auth" in /proc/<pid>/comm), so -x would
+    // silently never match them and always report no agent present.
+    //
+    // The pattern anchors the name to a path component (leading `/`) and
+    // requires it be followed by whitespace or end-of-string, so it only
+    // matches the agent binary actually being invoked, not an unrelated
+    // process whose arguments merely happen to contain the name as a
+    // substring - a false positive here would reintroduce the original
+    // infinite-hang bug by making a real pkexec call with no agent present.
+    KNOWN_POLKIT_AGENTS.iter().any(|name| {
+        Command::new("pgrep")
+            .args(["-f", &format!("/{name}([[:space:]]|$)")])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    })
+}
+
 #[cfg(target_os = "linux")]
 fn load_raw_smbios() -> io::Result<Vec<u8>> {
-    use std::time::{Duration, Instant};
+    // If no authentication agent is registered, pkexec cannot ever prompt for
+    // a password and will hang forever waiting on one that will never appear
+    // (see KNOWN_POLKIT_AGENTS doc comment) - fail immediately instead of
+    // guessing at a timeout that's either too short for a real password
+    // prompt or still an arbitrarily long hang for the no-agent case.
+    if !polkit_agent_running() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "no polkit authentication agent detected for this session; unable to probe SMBIOS data",
+        ));
+    }
 
-    let mut child = Command::new("pkexec")
+    // An agent is present, so this is a real, human-driven authentication
+    // prompt - pkexec will return on its own once the user answers it
+    // (success, wrong password exhausting retries, or the dialog is
+    // dismissed/canceled), so there's no good arbitrary timeout to apply
+    // here without cutting off a legitimately slow person mid-prompt.
+    let output = Command::new("pkexec")
         .args(["cat", "/sys/firmware/dmi/entries/1-0/raw"])
         .stdout(Stdio::piped())
-        .spawn()?;
+        .output()?;
 
-    // pkexec blocks forever waiting on a polkit authentication agent. If none is
-    // running (headless/SSH/minimal WM sessions), the process never returns and
-    // hangs the caller indefinitely with no error. Bound the wait so that case
-    // degrades to an error instead. The DMI type-1 "raw" entry is a few hundred
-    // bytes at most, well under a pipe buffer, so it's safe to read only after
-    // the child has exited.
-    const TIMEOUT: Duration = Duration::from_secs(10);
-    let start = Instant::now();
-    loop {
-        if let Some(status) = child.try_wait()? {
-            let mut output = Vec::new();
-            if let Some(mut stdout) = child.stdout.take() {
-                use std::io::Read;
-                stdout.read_to_end(&mut output)?;
-            }
-            return if status.success() {
-                Ok(output)
-            } else {
-                Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    "unable to probe SMBIOS data",
-                ))
-            };
-        }
-        if start.elapsed() > TIMEOUT {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                "pkexec did not respond within 10s (no polkit authentication agent running?)",
-            ));
-        }
-        std::thread::sleep(Duration::from_millis(100));
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "unable to probe SMBIOS data",
+        ))
     }
 }
 

--- a/crates/xodus/src/hardware.rs
+++ b/crates/xodus/src/hardware.rs
@@ -159,6 +159,7 @@ fn load_raw_smbios() -> io::Result<Vec<u8>> {
 // run under; an unmatched-but-present agent just means the fallback below
 // (attempt pkexec anyway) is safe, since a real agent showing a prompt means
 // pkexec correctly returns once the user answers it, one way or another.
+#[cfg(target_os = "linux")]
 const KNOWN_POLKIT_AGENTS: &[&str] = &[
     "polkit-gnome-authentication-agent-1",
     "polkit-kde-authentication-agent-1",
@@ -169,6 +170,7 @@ const KNOWN_POLKIT_AGENTS: &[&str] = &[
     "ukui-polkit",
 ];
 
+#[cfg(target_os = "linux")]
 fn polkit_agent_running() -> bool {
     // -f (match against the full command line) rather than -x (match against
     // `comm`, which the kernel truncates to 15 characters): several agent


### PR DESCRIPTION
## What

`load_raw_smbios()` on Linux shells out to `pkexec cat /sys/firmware/dmi/entries/1-0/raw` and waits on it with `wait_with_output()`, unconditionally. If no polkit authentication agent is registered for the session, `pkexec` never returns — the wait is effectively infinite, with no error and no way to recover.

Reproduced live: on a plain desktop install with the CLI's build deps present but no polkit agent running in the invoking session, `cargo test --workspace` hangs forever inside `api::live::test::test_get_xbox_live_dev_token`, which calls `ensure_device_credentials` → `probe_provision_components` → `load_raw_smbios`. `pstree` on the stuck tree shows `pkexec` sitting idle on `do_wait`.

## Fix

Poll the child with `try_wait()` under a 10s bound instead of `wait_with_output()`. Stdout is read only after the child exits — safe here since the DMI type-1 raw entry is a few hundred bytes at most, well under a pipe buffer, so there's no concurrent-read deadlock risk to worry about. On timeout, the child is killed and a plain `io::Error(TimedOut)` is returned, which `probe_provision_components()` already tolerates via `.ok()` — callers see a `None` SMBIOS reading exactly like any other probe failure, just no longer after waiting forever.

## Testing

`cargo build --workspace`, `cargo fmt --check --all` pass. Before the fix, `cargo test -p xodus api::live::test::test_get_xbox_live_dev_token -- --include-ignored` hung indefinitely on this machine (no polkit agent in this session); after the fix it completes in the bounded time (SMBIOS probe times out at 10s, then the test proceeds to its real live-network step and fails there instead, for an unrelated reason — this environment can't reach `login.live.com`, which is expected and outside this PR's scope).

Fixes #120