### PR TITLE
fix(licensing): handle satisfactionFailure instead of panicking

### DIFF
--- a/crates/xodus-cli/src/license.rs
+++ b/crates/xodus-cli/src/license.rs
@@ -70,7 +70,7 @@ pub async fn get_license(
         return Err("Unsupported token".to_string());
     };
 
-    let (_response, game_license) = xodus::licensing::content::get_license_content(
+    let (_content, game_license) = xodus::licensing::content::get_license_content(
         client,
         ms_device_token,
         user_token,
@@ -79,7 +79,7 @@ pub async fn get_license(
         market,
     )
     .await
-    .expect("failed to get license");
+    .map_err(|err| err.to_string())?;
 
     let game_splicense = SPLicense::parse_base64(&game_license.splicense_block)
         .expect("could not parse base64 game SPLicense");

--- a/crates/xodus/src/licensing/content.rs
+++ b/crates/xodus/src/licensing/content.rs
@@ -7,8 +7,20 @@ use xal::cvlib::CorrelationVector;
 use crate::licensing::utils;
 use crate::models::devicecredential::License;
 use crate::models::licensing::{
-    DeviceContext, LicenseContentRequest, LicenseContentResponse, LicenseUserIdentity,
+    DeviceContext, LicenseContent, LicenseContentRequest, LicenseContentResponse,
+    LicenseUserIdentity,
 };
+
+#[derive(Debug, thiserror::Error)]
+pub enum LicenseContentError {
+    #[error("request error: {0}")]
+    Request(#[from] reqwest::Error),
+
+    /// The account has no entitlement for the requested content (not owned, or
+    /// not covered by the account's current subscription tier).
+    #[error("not entitled to this content: {description}")]
+    NotEntitled { description: String },
+}
 
 // we might need a bump in xal-rs concerning reqwest,
 // that might block us from using the correlationvector extension
@@ -19,7 +31,7 @@ pub async fn get_license_content(
     ticket_reference: String,
     content_id: String,
     market: String,
-) -> reqwest::Result<(LicenseContentResponse, License)> {
+) -> Result<(LicenseContent, License), LicenseContentError> {
     let cv = CorrelationVector::new();
     let response = client
         .post("https://licensing.mp.microsoft.com/v7.0/licenses/content")
@@ -49,8 +61,18 @@ pub async fn get_license_content(
         .await?;
 
     let content_res = response.json::<LicenseContentResponse>().await?;
-    let license = &content_res.license.keys[0].value;
+    let content = match content_res {
+        LicenseContentResponse::Success { license } => license,
+        LicenseContentResponse::SatisfactionFailure {
+            satisfaction_failure,
+        } => {
+            return Err(LicenseContentError::NotEntitled {
+                description: satisfaction_failure.description,
+            });
+        }
+    };
+    let license = &content.keys[0].value;
     let license = BASE64_STANDARD.decode(license).unwrap();
     let license = quick_xml::de::from_str::<License>(&String::from_utf8(license).unwrap()).unwrap();
-    Ok((content_res, license))
+    Ok((content, license))
 }

--- a/crates/xodus/src/models/licensing.rs
+++ b/crates/xodus/src/models/licensing.rs
@@ -43,9 +43,24 @@ pub struct LicenseUserIdentity {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum LicenseContentResponse {
+    Success {
+        license: LicenseContent,
+    },
+    SatisfactionFailure {
+        #[serde(rename = "satisfactionFailure")]
+        satisfaction_failure: SatisfactionFailure,
+    },
+}
+
+/// Returned instead of a license when the account has no entitlement for the
+/// requested content (e.g. not owned, not covered by the account's Game Pass tier).
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct LicenseContentResponse {
-    pub license: LicenseContent,
+pub struct SatisfactionFailure {
+    pub code: i64,
+    pub description: String,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## What

`get_license_content` deserialized the licensing endpoint response directly into `LicenseContentResponse { license: LicenseContent }`. When the account has no entitlement for the requested content, the server returns a `satisfactionFailure` object instead (no `license` field), which failed deserialization and panicked at the `.expect("failed to get license")` call site in `xodus-cli/src/license.rs` with an opaque `missing field \`license\`` error.

This is exactly what issue #19 asked for ("Instead of printing a error about some missing field 'license', better say something better formatted"). I hit the same bug independently and initially filed it as #122 before finding #19 already existed - closed #122 as a duplicate.

## Fix

- `LicenseContentResponse` is now an untagged enum with `Success { license }` / `SatisfactionFailure { satisfaction_failure }` variants, mirroring the existing `PackageResponse::Found`/`NotFound` pattern in `models/packagespc.rs`.
- Added `LicenseContentError` (`thiserror`) with a `NotEntitled { description }` variant carrying the server's own human-readable description.
- The one call site (`xodus-cli/src/license.rs::get_license`) already returns `Result<_, String>` and already discarded the first tuple element, so this is a `.map_err(...)?` swap.

## Testing

Against a real, currently-authenticated account, each run multiple times:

- **Failure path (x3):** a title the account isn't entitled to → clean `not entitled to this content: Users do not possess any satisfying entitlements for the content id in question.`, process exits normally instead of panicking.
- **Success path (x3):** a real, currently-entitled title (Balatro, StoreId `9PK087LNGJC5`) downloads and fully extracts end-to-end through the restructured `Success` branch (exit 0 each time) - confirming the field-access restructuring didn't break the common case.

`cargo build/test --workspace`, `cargo fmt --check --all` all pass.

Fixes #19