### PR TITLE
fix(cli): clean error instead of a panic when not logged in

### DIFF
--- a/crates/xodus-cli/src/license.rs
+++ b/crates/xodus-cli/src/license.rs
@@ -14,8 +14,12 @@ pub async fn get_license(
     let Token::Legacy(dev_token) = dev_token else {
         return Err("Invalid STS token".to_string());
     };
-    let user = tokens.get_user().unwrap();
-    let user_token = tokens.get_user_sts_token().unwrap();
+    let user = tokens
+        .get_user()
+        .map_err(|_| "Not logged in - run `xodus-cli login` first".to_string())?;
+    let user_token = tokens
+        .get_user_sts_token()
+        .map_err(|_| "Not logged in - run `xodus-cli login` first".to_string())?;
     let Token::Legacy(legacy) = user_token else {
         return Err("Unspported user token".to_string());
     };
@@ -92,4 +96,53 @@ pub async fn get_license(
         .unwrap()
         .derive_device_key();
     Ok((key, game_splicense))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xodus::models::secrets::LegacyToken;
+    use xodus::tokens::PASSPORT_STS;
+
+    fn dummy_legacy_token() -> Token {
+        Token::Legacy(LegacyToken {
+            key_name: None,
+            token: "dummy".to_string(),
+            binary_secret: None,
+            tpm_key: None,
+            lifetime: soap::Timestamp {
+                id: None,
+                created: "2026-01-01T00:00:00Z".to_string(),
+                expires: "2099-01-01T00:00:00Z".to_string(),
+            },
+        })
+    }
+
+    #[tokio::test]
+    async fn get_license_gives_a_clean_error_when_not_logged_in() {
+        let tokens = TokenManager::with_memory();
+        // A device token is always present in real usage (ensure_device_credentials
+        // runs at binary startup), but deliberately no user/user-token here -
+        // this simulates a session that has never run `xodus-cli login`.
+        tokens
+            .save_device_token(PASSPORT_STS.to_string(), dummy_legacy_token())
+            .unwrap();
+
+        let client = reqwest::Client::new();
+        let result = get_license(
+            &client,
+            &tokens,
+            "unused-content-id".to_string(),
+            "US".to_string(),
+        )
+        .await;
+
+        let Err(err) = result else {
+            panic!("expected a clean error, not a panic, when not logged in");
+        };
+        assert!(
+            err.contains("run `xodus-cli login` first"),
+            "unexpected error message: {err}"
+        );
+    }
 }

--- a/crates/xodus-cli/src/package.rs
+++ b/crates/xodus-cli/src/package.rs
@@ -83,7 +83,11 @@ pub async fn get_packages(
     let Token::Legacy(dev_token) = dev_token else {
         return Err(Box::new(std::io::Error::other("Invalid STS token")));
     };
-    let user_token = tokens.get_user_sts_token().unwrap();
+    let user_token = tokens.get_user_sts_token().map_err(|_| {
+        Box::new(std::io::Error::other(
+            "Not logged in - run `xodus-cli login` first",
+        )) as Box<dyn std::error::Error>
+    })?;
     let Token::Legacy(legacy) = user_token else {
         return Err(Box::new(std::io::Error::other("Unsupported user token")));
     };
@@ -112,4 +116,46 @@ pub async fn get_packages(
         )));
     };
     Ok(package)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xodus::models::secrets::LegacyToken;
+    use xodus::models::soap::Timestamp;
+    use xodus::tokens::PASSPORT_STS;
+
+    fn dummy_legacy_token() -> Token {
+        Token::Legacy(LegacyToken {
+            key_name: None,
+            token: "dummy".to_string(),
+            binary_secret: None,
+            tpm_key: None,
+            lifetime: Timestamp {
+                id: None,
+                created: "2026-01-01T00:00:00Z".to_string(),
+                expires: "2099-01-01T00:00:00Z".to_string(),
+            },
+        })
+    }
+
+    #[tokio::test]
+    async fn get_packages_gives_a_clean_error_when_not_logged_in() {
+        let tokens = TokenManager::with_memory();
+        // A device token is always present in real usage (ensure_device_credentials
+        // runs at binary startup), but deliberately no user token here - this
+        // simulates a session that has never run `xodus-cli login`.
+        tokens
+            .save_device_token(PASSPORT_STS.to_string(), dummy_legacy_token())
+            .unwrap();
+
+        let client = reqwest::Client::new();
+        let result = get_packages(&client, &tokens, "unused-content-id".to_string()).await;
+
+        let err = result.expect_err("expected a clean error, not a panic, when not logged in");
+        assert!(
+            err.to_string().contains("run `xodus-cli login` first"),
+            "unexpected error message: {err}"
+        );
+    }
 }


### PR DESCRIPTION
## What

`get_packages()` and `get_license()` called `.unwrap()` directly on `tokens.get_user_sts_token()`/`get_user()`. If the session has never run `xodus-cli login`, these return `Err(NotFound)`, and the `.unwrap()` panicked with an opaque `called \`Result::unwrap()\` on an \`Err\` value: NotFound` instead of telling the user what to do. `download`, `streaming`, `run`, and (in #126) `library` all go through `get_packages`/`get_license`, so this affected the whole CLI surface, not just one command.

Device tokens are left as-is (still `.unwrap()`) since `ensure_device_credentials()` unconditionally provisions one at binary startup before any subcommand runs - that unwrap is safe by construction. Only the user-token/user-info calls, which require an explicit `login` the binary does not do automatically, are fixed.

## Testing

- Reproduced live first: a standalone repro against a fresh `TokenManager::with_memory()` confirmed the exact panic (`Result::unwrap() on an Err value: NotFound`).
- Added a unit test per fixed function (`get_packages`, `get_license`) that seeds a device token but deliberately no user token - the minimum needed to isolate this exact bug without hitting the (unrelated, already-safe) device-token unwrap first - and asserts a clean, actionable error instead of a panic.
- `cargo build/test --workspace` (including under `RUSTFLAGS="-D warnings"`), `cargo fmt --check --all` all pass.

Fixes #18