### PR TITLE
fix(cli): guard against infinite recursion resolving bundles

### DIFF
--- a/crates/xodus-cli/src/package.rs
+++ b/crates/xodus-cli/src/package.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use inquire::Select;
 use xodus::XBOX_LIVE_PACKAGES_PC;
 use xodus::api::displaycatalog::find_products_by_id;
@@ -10,6 +12,26 @@ pub async fn get_content_id(
     product: String,
     market: Option<String>,
 ) -> Result<String, Box<dyn std::error::Error>> {
+    get_content_id_impl(client, product, market, &mut HashSet::new()).await
+}
+
+/// `seen` tracks every product id already visited in this resolution chain.
+/// A bundle's sub-products can include the bundle's own id (observed live
+/// with the Minecraft bundle from #17: resolving one of its listed
+/// sub-products just returns the same bundle again) - without this guard,
+/// selecting that entry recurses into itself forever.
+async fn get_content_id_impl(
+    client: &reqwest::Client,
+    product: String,
+    market: Option<String>,
+    seen: &mut HashSet<String>,
+) -> Result<String, Box<dyn std::error::Error>> {
+    if !seen.insert(product.clone()) {
+        return Err(Box::new(std::io::Error::other(format!(
+            "bundle resolution looped back to an already-visited product id ({product}); refusing to recurse forever"
+        ))));
+    }
+
     let displaycatalog = find_products_by_id(
         client,
         product,
@@ -48,6 +70,9 @@ pub async fn get_content_id(
     }
     subprods.sort();
     subprods.dedup();
+    // Drop anything already visited (e.g. the bundle's own id showing up in
+    // its own sub-product list) before it's even offered as a choice.
+    subprods.retain(|id| !seen.contains(id));
 
     let Some(package) = found_package else {
         if !subprods.is_empty() {
@@ -57,7 +82,7 @@ pub async fn get_content_id(
             else {
                 return Err(Box::new(std::io::Error::other("Selection failed")));
             };
-            return Box::pin(get_content_id(client, item, market)).await;
+            return Box::pin(get_content_id_impl(client, item, market, seen)).await;
         }
 
         return Err(Box::new(std::io::Error::other(


### PR DESCRIPTION
## What

`get_content_id()` recurses into a user-selected sub-product when the requested id turns out to be a bundle (no direct `Windows.Desktop` package, but entitlement-key-derived sub-products exist). A bundle's own id can show up in its own sub-product list - reproduced live with the Minecraft bundle from #17 (`9NXP44L49SHJ` appears as one of its own `big:` entitlement keys, matching @ChristopherHX's own comment on #17 listing the same candidates). Selecting that entry recursed into the same id forever with no diagnostic.

## Fix

Track every product id visited in the current resolution chain in a `HashSet` threaded through a new private `get_content_id_impl`:
- drop already-visited ids from the candidate list before it's even shown, so the hazardous entry is no longer offered, and
- as a backstop, error clearly instead of recursing if one slips through anyway.

`get_content_id()`'s public signature is unchanged, so this doesn't ripple into its two call sites (`download.rs`, `streaming.rs`).

## Testing

Reproduced live against the exact bundle from #17 (`9NXP44L49SHJ`):

- **Before:** the picker listed `9NXP44L49SHJ` alongside the real sub-products (5 candidates, matching the maintainer's own comment on #17).
- **After:** that entry no longer appears (4 candidates instead of 5), and selecting one of the real remaining sub-products (`9NBLGGH2JHXJ`) resolves correctly through to its real file listing (Minecraft UWP).

This code path is interactive (`inquire::Select` needs a real terminal), so it isn't unit-tested - verified live instead, noting that deliberately rather than skipping verification.

`cargo build/test --workspace` (including under `RUSTFLAGS="-D warnings"`), `cargo fmt --check --all` all pass.

## Note

This fixes the recursion hazard #17 also flagged, not the issue's broader ask (showing resolved names instead of raw ids for the remaining candidates) - that needs extending the displaycatalog models with title metadata, which felt like a separate, bigger change to bundle with a safety fix. Happy to follow up separately if wanted.

Related to #17