### PR TITLE
fix(cli): clean error instead of a panic on a missing local file

### DIFF
--- a/crates/xodus-cli/src/commands/streaming.rs
+++ b/crates/xodus-cli/src/commands/streaming.rs
@@ -42,8 +42,20 @@ pub async fn run(
     let (tx, rx) = tokio::sync::mpsc::channel::<ProgressEvent>(256);
     if source.starts_with("file://") {
         let fsrc = source.strip_prefix("file://").unwrap_or_default();
-        let f = File::open(fsrc).await.unwrap();
-        let l = f.metadata().await.unwrap().len();
+        let f = match File::open(fsrc).await {
+            Ok(f) => f,
+            Err(err) => {
+                eprintln!("could not open {fsrc}: {err}");
+                return ExitCode::FAILURE;
+            }
+        };
+        let l = match f.metadata().await {
+            Ok(metadata) => metadata.len(),
+            Err(err) => {
+                eprintln!("could not read metadata for {fsrc}: {err}");
+                return ExitCode::FAILURE;
+            }
+        };
         run_cli_reader(
             client,
             tokens,


### PR DESCRIPTION
## What

Previously unreported. `xodus-cli extract` (which forwards to `streaming::run` with a `file://` source) panicked with a raw OS error if the given path didn't exist or its metadata couldn't be read, instead of a clear message. `File::open(...).unwrap()` and `.metadata().await.unwrap()` are now matched explicitly.

## Testing

- Reproduced live: nonexistent path → raw `called \`Result::unwrap()\` on an \`Err\` value: Os { code: 2, ...}` panic.
- After the fix: clean `could not open <path>: No such file or directory` and a failure exit code instead. Run twice for consistency.
- Confirmed the success path is unaffected: a real, readable local file still passes through this exact code correctly - it fails later, at an unrelated, pre-existing `"no err"` panic while parsing invalid msixvc content. That one's bigger (21 similar `.expect()`/`.unwrap()` call sites in the same file, in functions that currently return `()` with no error path at all) so I filed it separately as #130 rather than bundle a much larger, harder-to-fully-test change with this small, isolated fix.
- `cargo build/test --workspace` (including under `RUSTFLAGS="-D warnings"`), `cargo fmt --check --all` all pass.