### PR TITLE
fix(cli): don't require device credentials for offline-only commands

### DIFF
--- a/crates/xodus-cli/src/commands/splicense.rs
+++ b/crates/xodus-cli/src/commands/splicense.rs
@@ -3,8 +3,17 @@ use std::process::ExitCode;
 use base64::prelude::*;
 use xodus::licensing::splicense::SPLicense;
 pub fn run(block: String) -> ExitCode {
-    let license = SPLicense::parse_base64(&block).expect("Failed to parse SPLicenseBlock");
-    let clep_sign_state = license.clep_sign_state.unwrap();
+    let license = match SPLicense::parse_base64(&block) {
+        Ok(license) => license,
+        Err(err) => {
+            eprintln!("failed to parse SPLicenseBlock: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let Some(clep_sign_state) = license.clep_sign_state else {
+        eprintln!("SPLicenseBlock has no ClepSignState");
+        return ExitCode::FAILURE;
+    };
     let key = clep_sign_state.get_rsa_key();
 
     println!("RSA key is {:?}", BASE64_STANDARD.encode(*key));

--- a/crates/xodus-cli/src/main.rs
+++ b/crates/xodus-cli/src/main.rs
@@ -122,7 +122,20 @@ async fn main() -> ExitCode {
 
     xodus::secrets::init_secrets().expect("Unable to initialize credentials");
     let tokens = TokenManager::with_keychain_and_memory();
-    xodus::tokens::device::ensure_device_credentials(&client, &tokens).await;
+
+    // Clep/SpLicense are pure local data transforms and Logout only removes
+    // stored credentials - none of them need a device identity, so don't
+    // force provisioning (network + keychain access) just to run them. This
+    // matters in practice: on a session with no usable secret-service
+    // keychain, provisioning fails outright, which previously meant even
+    // these fully offline commands were unusable.
+    let needs_device_credentials = !matches!(
+        args.command,
+        SubCommand::Clep { .. } | SubCommand::SpLicense { .. } | SubCommand::Logout { .. }
+    );
+    if needs_device_credentials {
+        xodus::tokens::device::ensure_device_credentials(&client, &tokens).await;
+    }
 
     let code = match args.command {
         SubCommand::Download {


### PR DESCRIPTION
## What

`main()` unconditionally called `ensure_device_credentials()` (network + keychain access) before dispatching to any subcommand at all, including `Clep` and `SpLicense`, which are pure local data transforms with no auth of any kind, and `Logout`, which only removes stored credentials. On a session with no usable secret-service keychain, provisioning fails outright - which meant these fully offline commands were completely unusable, panicking before ever reaching their own logic.

## Fix

Skip `ensure_device_credentials` for `Clep`/`SpLicense`/`Logout` specifically; every other subcommand (`Download`, `License`, `Extract`, `Streaming`, `Run`, `Login`) still gets it exactly as before.

Also fixed a small, separately-noticed panic in `splicense.rs`: `sp-license` with a non-base64 argument panicked with `"Failed to parse SPLicenseBlock"` instead of a clean error - this became visible once the keychain-gating panic above no longer masked it.

## Testing

- Reproduced live: `xodus-cli clep generate` (no arguments even required) panicked with `Failed to save device license: Keychain(...)` in a session with no accessible keyring. After the fix it runs and produces output with zero keychain/network access.
- Confirmed no regression: `download --dry-run` against a real logged-in session still correctly provisions/uses device credentials and proceeds to its normal logic.
- `sp-license` with invalid input: clean error, verified live twice.
- `cargo build/test --workspace` (including under `RUSTFLAGS="-D warnings"`), `cargo fmt --check --all` all pass.

## Note

Once #126 (`catalog`/`library` commands) merges, `Catalog` should also be added to the skip-list - it needs zero auth too (public API). Couldn't include that here since that subcommand doesn't exist on `main` yet.