### PR TITLE
fix(cli): download --dry-run only printed the first selected file's URL

### DIFF
--- a/crates/xodus-cli/src/commands/download.rs
+++ b/crates/xodus-cli/src/commands/download.rs
@@ -62,7 +62,7 @@ pub async fn run(
         );
         if dry_run {
             println!("{}", url);
-            return ExitCode::SUCCESS;
+            continue;
         }
 
         let progress_bar = ProgressBar::new(file.file_size as u64).with_style(


### PR DESCRIPTION
## What

Previously unreported. The `MultiSelect` prompt explicitly lets (and validates for) selecting more than one file, but the `--dry-run` branch inside the per-file loop did `return ExitCode::SUCCESS` instead of `continue` - so with multiple files selected, only the first one's URL got printed and the rest were silently dropped, along with the final `"ContentID: ..."` line.

## Fix

One-word change: `return ExitCode::SUCCESS` → `continue`.

## Testing

Reproduced live with a real package (Balatro, StoreId `9PK087LNGJC5`) - selected all 4 available files:

- **Before:** only 1 URL printed.
- **After:** all 4 URLs print, plus the `ContentID:` line. Confirmed on two separate runs.

`cargo build/test --workspace` (including under `RUSTFLAGS="-D warnings"`), `cargo fmt --check --all` all pass.