### PR TITLE
fix(service): don't panic on a fault/non-collection user token response

### DIFF
--- a/crates/xodus-service/src/connection/xml.rs
+++ b/crates/xodus-service/src/connection/xml.rs
@@ -124,7 +124,7 @@ pub async fn parse_message(
                     let payload = quick_xml::se::to_string(&payload)?;
                     Ok(payload.as_bytes().to_vec())
                 }
-                _ => todo!("Error handling sill sucks"),
+                _ => Err("Failed to exchange user token".into()),
             }
         }
         _ => Err("Unimplemented".into()),


### PR DESCRIPTION
## What

The `MsaTokenRequest` handler only handled `ExchangeUserTokenOutcome::Issued(RequestSecurityTokenResponseCollection)`, falling through to `todo!("Error handling sill sucks")` for anything else - including the `Fault` variant returned when the exchange itself fails, and the single-response `Issued` shape. Both are reachable in normal operation (a `Fault` is a real, non-exceptional response from the token service), not a hypothetical.

## Fix

Return a plain `Err` instead, matching the sibling `_ => Err(...)` arm one case above in the same match. The caller (`xml::handle`) already turns any `Err` from `parse_message` into a logged error and an empty response instead of crashing the connection, so this fits the existing error handling without further changes.

## Note on testing

Unlike this session's other fixes, I could not verify this live - triggering a real `Fault` response needs a specific, hard-to-manufacture server-side condition during MSA token exchange, and there's no existing test client for `xodus-service`'s IPC protocol to script one. This is a mechanical, type-checked change (the two arms of this match already return the exact same `Result` type; this just changes what the catch-all arm does with it), verified by build/test rather than a live repro - saying that plainly rather than implying more confidence than I actually have.

`cargo build/test --workspace` (including under `RUSTFLAGS="-D warnings"`), `cargo fmt --check --all` all pass.