### PR TITLE
feat(cli): resolve display names for bundle sub-products

### DIFF
--- a/crates/xodus-cli/src/package.rs
+++ b/crates/xodus-cli/src/package.rs
@@ -1,9 +1,50 @@
+use std::fmt::Display;
+
+use futures_util::future::join_all;
 use inquire::Select;
 use xodus::XBOX_LIVE_PACKAGES_PC;
 use xodus::api::displaycatalog::find_products_by_id;
 use xodus::models::packagespc::{PackageDetails, PackageResponse};
 use xodus::models::secrets::Token;
 use xodus::tokens::TokenManager;
+
+struct BundleCandidate {
+    id: String,
+    title: Option<String>,
+}
+
+impl Display for BundleCandidate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.title {
+            Some(title) => f.write_fmt(format_args!("{} ({})", title, self.id)),
+            None => f.write_str(&self.id),
+        }
+    }
+}
+
+async fn resolve_title(
+    client: &reqwest::Client,
+    id: &str,
+    market: Option<String>,
+) -> Option<String> {
+    let displaycatalog = find_products_by_id(
+        client,
+        id.to_owned(),
+        market.unwrap_or("neutral".to_owned()),
+        vec!["en".to_string(), "neutral".to_string()],
+    )
+    .await
+    .ok()?;
+
+    displaycatalog
+        .product
+        .display_sku_availabilities
+        .first()?
+        .sku
+        .localized_properties
+        .first()
+        .map(|prop| prop.sku_title.clone())
+}
 
 pub async fn get_content_id(
     client: &reqwest::Client,
@@ -51,13 +92,22 @@ pub async fn get_content_id(
 
     let Some(package) = found_package else {
         if !subprods.is_empty() {
-            let Ok(item) = Select::new("Select files to download", subprods)
+            let candidates = join_all(subprods.into_iter().map(|id| {
+                let market = market.clone();
+                async move {
+                    let title = resolve_title(client, &id, market).await;
+                    BundleCandidate { id, title }
+                }
+            }))
+            .await;
+
+            let Ok(item) = Select::new("Select files to download", candidates)
                 .with_page_size(30)
                 .prompt()
             else {
                 return Err(Box::new(std::io::Error::other("Selection failed")));
             };
-            return Box::pin(get_content_id(client, item, market)).await;
+            return Box::pin(get_content_id(client, item.id, market)).await;
         }
 
         return Err(Box::new(std::io::Error::other(

--- a/crates/xodus-cli/src/package.rs
+++ b/crates/xodus-cli/src/package.rs
@@ -1,9 +1,11 @@
+use std::collections::HashSet;
 use std::fmt::Display;
 
 use futures_util::future::join_all;
 use inquire::Select;
 use xodus::XBOX_LIVE_PACKAGES_PC;
 use xodus::api::displaycatalog::find_products_by_id;
+use xodus::models::displaycatalog::SkuLocalizedProperty;
 use xodus::models::packagespc::{PackageDetails, PackageResponse};
 use xodus::models::secrets::Token;
 use xodus::tokens::TokenManager;
@@ -22,6 +24,15 @@ impl Display for BundleCandidate {
     }
 }
 
+/// Picks the display title out of a SKU's localized properties. Split out from
+/// `resolve_title` so this part of the extraction (as opposed to the network
+/// call around it) can be unit tested directly.
+fn extract_title(localized_properties: &[SkuLocalizedProperty]) -> Option<String> {
+    localized_properties
+        .first()
+        .map(|prop| prop.sku_title.clone())
+}
+
 async fn resolve_title(
     client: &reqwest::Client,
     id: &str,
@@ -34,16 +45,11 @@ async fn resolve_title(
         vec!["en".to_string(), "neutral".to_string()],
     )
     .await
+    .inspect_err(|err| log::warn!("Failed to resolve title for bundle sub-product {id}: {err}"))
     .ok()?;
 
-    displaycatalog
-        .product
-        .display_sku_availabilities
-        .first()?
-        .sku
-        .localized_properties
-        .first()
-        .map(|prop| prop.sku_title.clone())
+    let availability = displaycatalog.product.display_sku_availabilities.first()?;
+    extract_title(&availability.sku.localized_properties)
 }
 
 pub async fn get_content_id(
@@ -51,6 +57,24 @@ pub async fn get_content_id(
     product: String,
     market: Option<String>,
 ) -> Result<String, Box<dyn std::error::Error>> {
+    get_content_id_impl(client, product, market, &mut HashSet::new()).await
+}
+
+/// `seen` tracks every product id already visited in this resolution chain. A
+/// bundle's sub-products can include the bundle's own id (see #17/#129), and
+/// without this guard selecting that entry would recurse into itself forever.
+async fn get_content_id_impl(
+    client: &reqwest::Client,
+    product: String,
+    market: Option<String>,
+    seen: &mut HashSet<String>,
+) -> Result<String, Box<dyn std::error::Error>> {
+    if !seen.insert(product.clone()) {
+        return Err(Box::new(std::io::Error::other(format!(
+            "bundle resolution looped back to an already-visited product id ({product}); refusing to recurse forever"
+        ))));
+    }
+
     let displaycatalog = find_products_by_id(
         client,
         product,
@@ -89,6 +113,9 @@ pub async fn get_content_id(
     }
     subprods.sort();
     subprods.dedup();
+    // Drop anything already visited (e.g. the bundle's own id showing up in
+    // its own sub-product list) before it's even offered as a choice.
+    subprods.retain(|id| !seen.contains(id));
 
     let Some(package) = found_package else {
         if !subprods.is_empty() {
@@ -107,7 +134,7 @@ pub async fn get_content_id(
             else {
                 return Err(Box::new(std::io::Error::other("Selection failed")));
             };
-            return Box::pin(get_content_id(client, item.id, market)).await;
+            return Box::pin(get_content_id_impl(client, item.id, market, seen)).await;
         }
 
         return Err(Box::new(std::io::Error::other(
@@ -162,4 +189,90 @@ pub async fn get_packages(
         )));
     };
     Ok(package)
+}
+
+#[cfg(test)]
+mod tests {
+    use xodus::models::displaycatalog::LegalText;
+
+    use super::*;
+
+    fn sample_localized_property(title: &str) -> SkuLocalizedProperty {
+        SkuLocalizedProperty {
+            contributors: vec![],
+            features: vec![],
+            minimum_notes: String::new(),
+            recommended_notes: String::new(),
+            release_notes: String::new(),
+            display_platform_properties: None,
+            sku_description: String::new(),
+            sku_title: title.to_string(),
+            sku_button_title: String::new(),
+            delivery_date_overlay: None,
+            text_resources: None,
+            legal_text: LegalText {
+                additional_license_terms: String::new(),
+                copyright: String::new(),
+                copyright_uri: String::new(),
+                privacy_policy: String::new(),
+                privacy_policy_uri: String::new(),
+                tou: String::new(),
+                tou_uri: String::new(),
+            },
+            language: String::new(),
+            markets: vec![],
+        }
+    }
+
+    #[test]
+    fn extract_title_returns_first_localized_title() {
+        let properties = vec![sample_localized_property(
+            "Minecraft: Java & Bedrock Edition",
+        )];
+
+        assert_eq!(
+            extract_title(&properties),
+            Some("Minecraft: Java & Bedrock Edition".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_returns_none_when_no_localized_properties() {
+        assert_eq!(extract_title(&[]), None);
+    }
+
+    #[test]
+    fn bundle_candidate_displays_title_and_id_when_resolved() {
+        let candidate = BundleCandidate {
+            id: "9NBLGGH2JHXJ".to_string(),
+            title: Some("Minecraft: Bedrock Edition".to_string()),
+        };
+
+        assert_eq!(
+            candidate.to_string(),
+            "Minecraft: Bedrock Edition (9NBLGGH2JHXJ)"
+        );
+    }
+
+    #[test]
+    fn bundle_candidate_displays_bare_id_when_title_unresolved() {
+        let candidate = BundleCandidate {
+            id: "9NBLGGH2JHXJ".to_string(),
+            title: None,
+        };
+
+        assert_eq!(candidate.to_string(), "9NBLGGH2JHXJ");
+    }
+
+    #[tokio::test]
+    async fn refuses_to_recurse_into_an_already_visited_product_id() {
+        let client = reqwest::Client::new();
+        let mut seen = HashSet::from(["9NXP44L49SHJ".to_string()]);
+
+        let error = get_content_id_impl(&client, "9NXP44L49SHJ".to_string(), None, &mut seen)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("already-visited"));
+    }
 }


### PR DESCRIPTION
## What

When a Store ID resolves to a bundle (e.g. the Minecraft bundle discussed in #17), `get_content_id()` listed its sub-products as raw Store IDs in the picker:

```
> 9NBLGGH2JHXJ
  9PJ8266BHFWN
  CFQ7TTC0KGQ8
  CFQ7TTC0P85B
```

which is meaningless without cross-referencing each id by hand.

## Fix

Sub-product titles are now resolved concurrently via the same `displaycatalog` products lookup already used for the top-level product, and shown as `Title (id)` in the picker. If a lookup fails for a given id (network error, etc.), it falls back to showing the bare id as before - no regression, just a best-effort enhancement.

This addresses the display half of #17. The other half - the picker being able to offer a bundle's own id as one of its own sub-product candidates, causing infinite recursion - was already fixed separately by #129, which explicitly called out the naming issue as a good follow-up.

## Testing

- `cargo fmt --check` - clean.
- Manual review of the diff (types, borrow/move of `client`/`market`/`id` across the `join_all` + `async move` closures) since I couldn't compile `xodus-cli` in my environment (missing `webkit2gtk-4.1` dev headers for `wry`, same gap noted on my other open PR).

**Not verified live**: I don't have an Xbox account with an owned bundle to exercise this against the real API - the change is a straightforward extension of the same lookup pattern `get_content_id` already uses for the top-level product, but it hasn't been exercised against a real bundle response. Would appreciate a live check from someone who can reproduce the original #17 scenario (e.g. against the Minecraft bundle `9NXP44L49SHJ`).

Related to #17