### PR TITLE
fix(hardware): report unreadable SMBIOS fields as errors instead of panicking

### DIFF
--- a/crates/xodus/src/hardware.rs
+++ b/crates/xodus/src/hardware.rs
@@ -13,6 +13,25 @@ use smbioslib::{SMBiosSystemInformation, SystemUuidData, table_load_from_device}
 use crate::clep;
 use crate::models::devicecredential::Component;
 
+/// The SMBIOS Type 1 fields sent during provisioning, each independently
+/// optional: firmware is free to omit any of them (a string index of 0 means
+/// "not specified"), and a structure predating SMBIOS 2.1 has no UUID field at
+/// all. A field that could not be read is reported as `Component::error`
+/// rather than aborting the whole probe.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct SmbiosFields {
+    pub version: Option<Vec<u8>>,
+    pub serial: Option<Vec<u8>>,
+    pub uuid: Option<[u8; 16]>,
+}
+
+fn push_field(components: &mut Vec<Component>, id: u32, value: Option<impl AsRef<[u8]>>) {
+    match value {
+        Some(value) => components.push(Component::new(id, BASE64_STANDARD.encode(value))),
+        None => components.push(Component::error(id)),
+    }
+}
+
 pub fn probe_provision_components() -> Vec<Component> {
     let mut components = Vec::with_capacity(16);
     let drive_serial = BASE64_STANDARD.decode("AA==").unwrap();
@@ -20,7 +39,7 @@ pub fn probe_provision_components() -> Vec<Component> {
     let mut drive_buf = [0; 64];
 
     let smbios = load_raw_smbios().ok();
-    let parsed_smbios = load_smbios_fields(smbios.as_deref()).ok();
+    let parsed_smbios = load_smbios_fields(smbios.as_deref());
 
     drive_buf
         .iter_mut()
@@ -39,15 +58,9 @@ pub fn probe_provision_components() -> Vec<Component> {
     components.push(Component::new(8196, BASE64_STANDARD.encode(clepv2)));
     components.push(Component::new(8197, BASE64_STANDARD.encode(clepv4)));
 
-    if let Some((version, serial, uuid)) = parsed_smbios {
-        components.push(Component::new(4100, BASE64_STANDARD.encode(version)));
-        components.push(Component::new(4101, BASE64_STANDARD.encode(serial)));
-        components.push(Component::new(4102, BASE64_STANDARD.encode(uuid)));
-    } else {
-        components.push(Component::error(4100));
-        components.push(Component::error(4101));
-        components.push(Component::error(4102));
-    }
+    push_field(&mut components, 4100, parsed_smbios.version);
+    push_field(&mut components, 4101, parsed_smbios.serial);
+    push_field(&mut components, 4102, parsed_smbios.uuid);
 
     components.push(Component::new(4145, "AQAAAA==".to_string()));
     components.push(Component::error(4160));
@@ -76,73 +89,111 @@ pub fn probe_provision_components() -> Vec<Component> {
 }
 
 #[cfg(target_os = "linux")]
-fn load_smbios_fields(raw: Option<&[u8]>) -> io::Result<(Vec<u8>, Vec<u8>, [u8; 16])> {
-    let smbios =
-        raw.ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "missing raw SMBIOS data"))?;
-    Ok(parse_smbios(smbios))
+fn load_smbios_fields(raw: Option<&[u8]>) -> SmbiosFields {
+    raw.map(parse_smbios).unwrap_or_default()
 }
 
 #[cfg(not(target_os = "linux"))]
-fn load_smbios_fields(_raw: Option<&[u8]>) -> io::Result<(Vec<u8>, Vec<u8>, [u8; 16])> {
-    let data = table_load_from_device()?;
-    let system_info = data
-        .first::<SMBiosSystemInformation>()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "missing SMBIOS Type 1"))?;
-
-    let version = system_info
-        .version()
-        .to_utf8_lossy()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing SMBIOS version"))?
-        .into_bytes();
-    let serial = system_info
-        .serial_number()
-        .to_utf8_lossy()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing SMBIOS serial"))?
-        .into_bytes();
-    let uuid = match system_info.uuid() {
-        Some(SystemUuidData::Uuid(uuid)) => uuid.raw,
-        _ => {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "missing SMBIOS UUID",
-            ));
-        }
+fn load_smbios_fields(_raw: Option<&[u8]>) -> SmbiosFields {
+    let Ok(data) = table_load_from_device() else {
+        return SmbiosFields::default();
+    };
+    let Some(system_info) = data.first::<SMBiosSystemInformation>() else {
+        return SmbiosFields::default();
     };
 
-    Ok((version, serial, uuid))
+    SmbiosFields {
+        version: system_info
+            .version()
+            .to_utf8_lossy()
+            .map(String::into_bytes),
+        serial: system_info
+            .serial_number()
+            .to_utf8_lossy()
+            .map(String::into_bytes),
+        uuid: match system_info.uuid() {
+            Some(SystemUuidData::Uuid(uuid)) => Some(uuid.raw),
+            _ => None,
+        },
+    }
 }
 
+/// Parses an SMBIOS Type 1 (System Information) structure.
+///
+/// Every field is read defensively: the blob comes from firmware (by way of
+/// `pkexec cat`, which can succeed and return nothing), so a short, truncated
+/// or simply older structure must degrade to `Component::error` rather than
+/// take the process down.
 #[cfg(target_os = "linux")]
-fn parse_smbios(smbios: &[u8]) -> (Vec<u8>, Vec<u8>, [u8; 16]) {
-    let length = smbios[1];
+fn parse_smbios(smbios: &[u8]) -> SmbiosFields {
+    /// Offsets within the formatted section, per the SMBIOS spec.
+    const LENGTH_OFFSET: usize = 1;
+    const VERSION_INDEX_OFFSET: usize = 6;
+    const SERIAL_INDEX_OFFSET: usize = 7;
+    const UUID_OFFSET: usize = 8;
+    const UUID_LEN: usize = 16;
 
-    let version = smbios[6];
-    let serial = smbios[7];
-    let uuid: [u8; 16] = smbios[8..24].try_into().unwrap();
+    let (Some(&formatted_len), Some(&version_index), Some(&serial_index)) = (
+        smbios.get(LENGTH_OFFSET),
+        smbios.get(VERSION_INDEX_OFFSET),
+        smbios.get(SERIAL_INDEX_OFFSET),
+    ) else {
+        // Shorter than the SMBIOS 2.0 formatted section - nothing to read.
+        return SmbiosFields::default();
+    };
 
-    let stringsbuf = &smbios[length as usize..];
-    let mut strings: Vec<&[u8]> = Vec::new();
-    strings.push(&[]);
+    // The UUID only exists from SMBIOS 2.1 on; a 2.0 structure stops at 8
+    // bytes, so anything at this offset would belong to the next field or to
+    // the string set.
+    let uuid = smbios
+        .get(UUID_OFFSET..UUID_OFFSET + UUID_LEN)
+        .filter(|_| usize::from(formatted_len) >= UUID_OFFSET + UUID_LEN)
+        .and_then(|bytes| <[u8; UUID_LEN]>::try_from(bytes).ok());
+
+    // `formatted_len` is firmware-supplied and may point past the blob.
+    let strings = smbios
+        .get(usize::from(formatted_len)..)
+        .map(parse_smbios_strings)
+        .unwrap_or_default();
+
+    SmbiosFields {
+        version: smbios_string(&strings, version_index),
+        serial: smbios_string(&strings, serial_index),
+        uuid,
+    }
+}
+
+/// The unformatted section is a run of NUL-terminated strings, terminated by
+/// an empty one (i.e. a double NUL).
+#[cfg(target_os = "linux")]
+fn parse_smbios_strings(buf: &[u8]) -> Vec<&[u8]> {
+    let mut strings = Vec::new();
     let mut cursor = 0;
-    while cursor < stringsbuf.len() {
-        let end = stringsbuf[cursor..]
+
+    while cursor < buf.len() {
+        let end = buf[cursor..]
             .iter()
             .position(|&b| b == 0)
-            .unwrap_or(stringsbuf.len() - cursor)
-            + cursor;
-        let slice = &stringsbuf[cursor..end];
-        strings.push(slice);
-        cursor = end + 1;
-        if cursor >= stringsbuf.len() || stringsbuf[cursor] == 0 {
+            .map_or(buf.len(), |offset| cursor + offset);
+
+        if end == cursor {
+            // Empty string: end of the string set.
             break;
         }
+
+        strings.push(&buf[cursor..end]);
+        cursor = end + 1;
     }
 
-    (
-        strings[version as usize].to_vec(),
-        strings[serial as usize].to_vec(),
-        uuid,
-    )
+    strings
+}
+
+/// String references are 1-based; index 0 means "not specified", which is
+/// reported as a field error rather than as an empty value.
+#[cfg(target_os = "linux")]
+fn smbios_string(strings: &[&[u8]], index: u8) -> Option<Vec<u8>> {
+    let index = usize::from(index).checked_sub(1)?;
+    strings.get(index).map(|string| string.to_vec())
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios", target_family = "windows"))]
@@ -179,4 +230,106 @@ fn load_raw_smbios() -> io::Result<Vec<u8>> {
         io::ErrorKind::Unsupported,
         "raw SMBIOS loading is unsupported on this platform",
     ))
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::{SmbiosFields, parse_smbios};
+
+    /// A well-formed SMBIOS 2.4 Type 1 structure: manufacturer=1, product=2,
+    /// version=3, serial=4, a 16-byte UUID, wake-up type, sku=5, family=6.
+    fn type1(version_index: u8, serial_index: u8) -> Vec<u8> {
+        let mut structure = vec![
+            0x01,
+            0x1b,
+            0x01,
+            0x00,
+            0x01,
+            0x02,
+            version_index,
+            serial_index,
+        ];
+        structure.extend_from_slice(&[0xAA; 16]);
+        structure.extend_from_slice(&[0x06, 0x05, 0x06]);
+        for string in ["ACME", "Box", "1.0", "SN123", "SKU", "FAM"] {
+            structure.extend_from_slice(string.as_bytes());
+            structure.push(0);
+        }
+        structure.push(0);
+        structure
+    }
+
+    #[test]
+    fn reads_all_three_fields_from_a_well_formed_structure() {
+        assert_eq!(
+            parse_smbios(&type1(3, 4)),
+            SmbiosFields {
+                version: Some(b"1.0".to_vec()),
+                serial: Some(b"SN123".to_vec()),
+                uuid: Some([0xAA; 16]),
+            }
+        );
+    }
+
+    #[test]
+    fn an_empty_blob_yields_no_fields() {
+        // `pkexec cat` can exit 0 having written nothing.
+        assert_eq!(parse_smbios(&[]), SmbiosFields::default());
+    }
+
+    #[test]
+    fn a_blob_shorter_than_the_formatted_section_yields_no_fields() {
+        assert_eq!(parse_smbios(&[0x01, 0x1b, 0x01]), SmbiosFields::default());
+    }
+
+    #[test]
+    fn smbios_2_0_has_no_uuid_but_still_has_strings() {
+        // Type 1 was 8 bytes before SMBIOS 2.1 - the UUID field did not exist.
+        let mut structure = vec![0x01, 0x08, 0x01, 0x00, 0x01, 0x02, 0x03, 0x04];
+        structure.extend_from_slice(b"ACME\0Box\01.0\0SN123\0\0");
+
+        let fields = parse_smbios(&structure);
+        assert_eq!(fields.version.as_deref(), Some(&b"1.0"[..]));
+        assert_eq!(fields.serial.as_deref(), Some(&b"SN123"[..]));
+        assert_eq!(fields.uuid, None, "a 2.0 structure has no UUID to report");
+    }
+
+    #[test]
+    fn a_length_field_past_the_end_of_the_blob_yields_no_strings() {
+        let mut structure = type1(3, 4);
+        structure[1] = 0x7f;
+
+        let fields = parse_smbios(&structure);
+        assert_eq!(fields.version, None);
+        assert_eq!(fields.serial, None);
+        // the UUID sits in the formatted section and is still readable
+        assert_eq!(fields.uuid, Some([0xAA; 16]));
+    }
+
+    #[test]
+    fn a_string_index_past_the_string_set_is_a_field_error() {
+        let fields = parse_smbios(&type1(7, 4));
+        assert_eq!(fields.version, None);
+        assert_eq!(fields.serial.as_deref(), Some(&b"SN123"[..]));
+    }
+
+    #[test]
+    fn string_index_zero_means_not_specified() {
+        let fields = parse_smbios(&type1(0, 4));
+        assert_eq!(fields.version, None);
+        assert_eq!(fields.serial.as_deref(), Some(&b"SN123"[..]));
+    }
+
+    #[test]
+    fn a_truncated_string_set_still_yields_what_it_can() {
+        // No terminating double NUL - the last string runs to the end.
+        let mut structure = vec![0x01, 0x1b, 0x01, 0x00, 0x01, 0x02, 0x03, 0x04];
+        structure.extend_from_slice(&[0xAA; 16]);
+        structure.extend_from_slice(&[0x06, 0x05, 0x06]);
+        structure.extend_from_slice(b"ACME\0Box\01.0");
+
+        let fields = parse_smbios(&structure);
+        assert_eq!(fields.version.as_deref(), Some(&b"1.0"[..]));
+        assert_eq!(fields.serial, None);
+    }
 }


### PR DESCRIPTION
Fixes #144, following the direction you gave there: each field gets read independently and falls back to `Component::error` on its own, and a string index of `0` is treated as a field error too.

### What changed

`parse_smbios` now returns a `SmbiosFields { version, serial, uuid }` with each field optional, and `probe_provision_components` pushes `Component::new` or `Component::error` per field. Previously all three were discarded together if anything went wrong — and, more to the point, most failures didn't reach that fallback at all because they panicked first.

The four inputs from the issue are now covered by tests, along with a truncated string set and the happy path:

- empty blob → no fields
- blob shorter than the SMBIOS 2.0 formatted section → no fields
- SMBIOS 2.0 Type 1 (8 bytes, no UUID field) → version + serial still read, `uuid` reported as an error
- `length` byte past the end of the blob → strings unreadable, but the UUID sits in the formatted section and is still returned
- string index past the string set, and index `0` → that field errors, the other one still comes through

### On the provisioning-flow concern

You asked whether the error fallbacks might upset the provisioning flow. I can answer half of it with evidence and want to be clear about the other half.

**Verified:** on this machine's real Type 1 structure, the new parser produces byte-identical `version`, `serial` and UUID values to the old one — I ran both implementations side by side over `/sys/firmware/dmi/entries/1-0/raw` and asserted equality. So on any machine that provisions successfully today, the request body is unchanged and there is no behavioural difference to test for.

**Not verified:** whether login.live.com still issues a device license when one or more of 4100/4101/4102 comes through as `Component::error`.

*(Correcting myself: the first version of this paragraph claimed testing it would consume one of the account's device slots. That was wrong — per #109 it's `DeviceAssoc.srf` that reserves one of the 10 slots, and xodus never calls it. `deviceaddcredential.srf` carries no user token at all, so provisioning a throwaway credential costs nothing on the account.)*

So it is testable, and I'd rather measure it than guess: post the same request with 4100/4101/4102 forced to `Component::error`, against a control run with the real values, and see whether `Success` and the license block still come back. I'll report the result here. Worth noting the existing code path already sends `Component::error` for 4101, 4160 and 4161 unconditionally, so the service clearly tolerates *some* error components — just not necessarily these.

If you'd prefer the conservative version in the meantime, I can make it fall back to sending all three as errors when any one of them fails (i.e. preserve the old all-or-nothing shape, minus the panics) — say the word and I'll push that instead.

### Testing

`cargo test --workspace` and `cargo fmt --check --all` pass locally on Linux.

One thing I could not check here: the `#[cfg(not(target_os = "linux"))]` branch of `load_smbios_fields` also changed shape to return `SmbiosFields`. `smbios-lib` is a Linux-excluded dependency, so I can't type-check that arm locally and I don't have a macOS cross-compile set up — the change is a mechanical transformation of the existing body (`ok_or_else(..)?.into_bytes()` → `.map(String::into_bytes)`), but the macOS CI job is the real check on it.
