### PR TITLE
Issue tokens for the service a title is actually calling

### DIFF
--- a/crates/xodus-cli/src/commands/download.rs
+++ b/crates/xodus-cli/src/commands/download.rs
@@ -1,12 +1,18 @@
+use std::io::SeekFrom;
 use std::process::ExitCode;
+use std::time::Duration;
 
 use futures_util::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
 use inquire::MultiSelect;
 use inquire::validator::Validation;
-use tokio::io::AsyncWriteExt;
+use reqwest::header::RANGE;
+use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 use xodus::models::packagespc::PackageFile;
 use xodus::tokens::TokenManager;
+
+/// Consecutive attempts that move no bytes before a download is called off.
+const MAX_DOWNLOAD_ATTEMPTS: u32 = 10;
 
 use crate::package::{get_content_id, get_packages};
 
@@ -65,31 +71,120 @@ pub async fn run(
             continue;
         }
 
-        let progress_bar = ProgressBar::new(file.file_size as u64).with_style(
+        let total = file.file_size as u64;
+        let progress_bar = ProgressBar::new(total).with_style(
             ProgressStyle::with_template("[{elapsed_precise}] [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec}) ({eta})").unwrap()
             .progress_chars("#>-")
         );
 
-        let res = client
-            .get(url)
-            .send()
-            .await
-            .expect("Failed to request the download");
-        let mut file = tokio::fs::OpenOptions::new()
+        // Packages run to tens of gigabytes and the CDN drops long-lived streams,
+        // so a dropped connection has to resume rather than start over - which is
+        // also why an already partial file on disk is picked up instead of
+        // truncated. The CDN advertises Accept-Ranges: bytes.
+        let mut downloaded = match tokio::fs::metadata(&file.file_name).await {
+            Ok(meta) if meta.len() <= total => meta.len(),
+            _ => 0,
+        };
+
+        let mut handle = match tokio::fs::OpenOptions::new()
             .create(true)
             .write(true)
-            .truncate(true)
-            .open(file.file_name)
+            .truncate(downloaded == 0)
+            .open(&file.file_name)
             .await
-            .unwrap();
-        let mut stream = res.bytes_stream();
+        {
+            Ok(handle) => handle,
+            Err(err) => {
+                eprintln!("Failed to open {}: {err}", file.file_name);
+                return ExitCode::FAILURE;
+            }
+        };
 
-        while let Some(chunk) = stream.next().await {
-            let chk = chunk.expect("Failed to stream file");
-            file.write_all(&chk).await.expect("Failed to write to file");
-            progress_bar.inc(chk.len() as u64);
+        if downloaded > 0 {
+            if let Err(err) = handle.seek(SeekFrom::Start(downloaded)).await {
+                eprintln!("Failed to resume {}: {err}", file.file_name);
+                return ExitCode::FAILURE;
+            }
+            println!("Resuming {} at {downloaded} bytes", file.file_name);
+        }
+        progress_bar.set_position(downloaded);
+
+        let mut attempts = 0;
+        while downloaded < total {
+            let mut request = client.get(&url);
+            if downloaded > 0 {
+                request = request.header(RANGE, format!("bytes={downloaded}-"));
+            }
+
+            match request.send().await {
+                Ok(res) if res.status().is_success() => {
+                    // A server that ignores the range and replays the whole body
+                    // would corrupt the file, so only append when it agreed to it.
+                    if downloaded > 0 && res.status() != reqwest::StatusCode::PARTIAL_CONTENT {
+                        eprintln!("Server ignored the resume request, starting over");
+                        if handle.seek(SeekFrom::Start(0)).await.is_err() {
+                            eprintln!("Failed to rewind {}", file.file_name);
+                            return ExitCode::FAILURE;
+                        }
+                        downloaded = 0;
+                        progress_bar.set_position(0);
+                    }
+
+                    let mut stream = res.bytes_stream();
+                    let resumed_at = downloaded;
+                    while let Some(chunk) = stream.next().await {
+                        let chk = match chunk {
+                            Ok(chk) => chk,
+                            Err(err) => {
+                                progress_bar.println(format!("Stream interrupted: {err}"));
+                                break;
+                            }
+                        };
+                        if let Err(err) = handle.write_all(&chk).await {
+                            eprintln!("Failed to write to {}: {err}", file.file_name);
+                            return ExitCode::FAILURE;
+                        }
+                        downloaded += chk.len() as u64;
+                        progress_bar.set_position(downloaded);
+                    }
+                    // Only a retry that gained no ground counts against the budget,
+                    // otherwise a long download on a flaky link exhausts it.
+                    attempts = if downloaded > resumed_at { 0 } else { attempts + 1 };
+                }
+                Ok(res) => {
+                    progress_bar.println(format!("Download returned {}", res.status()));
+                    attempts += 1;
+                }
+                Err(err) => {
+                    progress_bar.println(format!("Request failed: {err}"));
+                    attempts += 1;
+                }
+            }
+
+            if downloaded >= total {
+                break;
+            }
+
+            if attempts > MAX_DOWNLOAD_ATTEMPTS {
+                progress_bar.abandon();
+                eprintln!(
+                    "Giving up on {} after {MAX_DOWNLOAD_ATTEMPTS} attempts with no progress ({downloaded}/{total} bytes). Re-run to resume.",
+                    file.file_name
+                );
+                return ExitCode::FAILURE;
+            }
+
+            if let Err(err) = handle.flush().await {
+                eprintln!("Failed to flush {}: {err}", file.file_name);
+                return ExitCode::FAILURE;
+            }
+            tokio::time::sleep(Duration::from_secs(2 * attempts.min(5) as u64)).await;
         }
 
+        if let Err(err) = handle.flush().await {
+            eprintln!("Failed to flush {}: {err}", file.file_name);
+            return ExitCode::FAILURE;
+        }
         progress_bar.finish();
     }
 

--- a/crates/xodus-cli/src/commands/run.rs
+++ b/crates/xodus-cli/src/commands/run.rs
@@ -13,6 +13,8 @@ use rustix::io::{FdFlags, fcntl_getfd, fcntl_setfd};
 #[cfg(not(target_os = "linux"))]
 use tempfile::{tempdir, tempfile, tempfile_in};
 use tokio::fs::{File, OpenOptions};
+use tokio::io::AsyncSeekExt;
+use std::io::SeekFrom;
 use tokio::process::Command;
 use xodus::tokens::TokenManager;
 
@@ -198,6 +200,17 @@ pub async fn run(
         xvd.mount_mem_fd(&mut i, &mut game_exe, file.1, *full_key, |_, _| {})
             .await
             .unwrap();
+
+        // Debug aid: the decrypted images only ever exist as memfds, which leaves no
+        // way to disassemble a crash address reported by the game itself.
+        if let Ok(dir) = std::env::var("XODUS_DUMP_DECRYPTED") {
+            let name = file.0.rsplit('\\').next().unwrap_or(file.0);
+            let dump_path = std::path::Path::new(&dir).join(name);
+            game_exe.seek(SeekFrom::Start(0)).await.unwrap();
+            let mut dump = tokio::fs::File::create(&dump_path).await.unwrap();
+            tokio::io::copy(&mut game_exe, &mut dump).await.unwrap();
+            eprintln!("dumped decrypted {} to {}", file.0, dump_path.display());
+        }
 
         let stdf = game_exe.into_std().await;
 

--- a/crates/xodus-cli/src/webview.rs
+++ b/crates/xodus-cli/src/webview.rs
@@ -325,6 +325,12 @@ fn create_session<T: SessionHandler>(
         state.window = Some(window);
     }
 
+    // Tear down any previous webview before the replacement gets parented. Handlers
+    // that close the old session first already leave this empty, but opening straight
+    // into a new session would otherwise leave two webviews in the same GTK vbox.
+    state.active_session = None;
+    state.active_webview = None;
+
     let window = state
         .window
         .as_ref()
@@ -378,10 +384,13 @@ fn create_session<T: SessionHandler>(
     let webview = {
         use tao::platform::unix::WindowExtUnix;
         use wry::WebViewBuilderExtUnix;
-        builder.build_gtk(window.default_vbox().unwrap()).unwrap()
+        let vbox = window
+            .default_vbox()
+            .ok_or_else(|| std::io::Error::other("window has no GTK vbox to host the webview"))?;
+        builder.build_gtk(vbox)?
     };
     #[cfg(not(target_os = "linux"))]
-    let webview = builder.build(&window).unwrap();
+    let webview = builder.build(window)?;
 
     state.active_session = Some(session_id);
     state.active_webview = Some(webview);

--- a/crates/xodus-service/src/connection/proto.rs
+++ b/crates/xodus-service/src/connection/proto.rs
@@ -1,8 +1,25 @@
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use xodus::proto::xodus::XodusMessageType;
+
+use crate::PROTO_MAGIC;
 use crate::simple_context::SimpleContext;
 
 pub async fn handle(
-    _socket: &mut tokio::net::UnixStream,
+    socket: &mut tokio::net::UnixStream,
     _context: &mut SimpleContext,
 ) -> tokio::io::Result<()> {
-    unimplemented!("Protobuf path isnt implemented yet");
+    // No handlers on this path yet, but a client speaking protobuf shouldn't take
+    // the worker down with it. Drain the frame so the stream stays aligned for the
+    // next message - bailing out early would leave the payload to be read as the
+    // following message's magic - then answer as UNKNOWN, matching how the XML
+    // path reports a message it has no handler for.
+    let message_type = socket.read_u16_le().await?;
+    let message_size = socket.read_u16_le().await?;
+    let mut buffer = vec![0; message_size as usize];
+    socket.read_exact(&mut buffer).await?;
+
+    log::error!("Protobuf path isnt implemented yet, dropping message type {message_type}");
+
+    let data = super::encode_message(PROTO_MAGIC, XodusMessageType::Unknown as u16, vec![]);
+    socket.write_all(&data).await
 }

--- a/crates/xodus-service/src/connection/xml.rs
+++ b/crates/xodus-service/src/connection/xml.rs
@@ -2,7 +2,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use xodus::models::live::ExchangeUserTokenOutcome;
 use xodus::models::secrets::Token;
 use xodus::models::soap;
-use xodus::models::xgameruntime::xuser::{MSATokenRequest, MSATokenResponse};
+use xodus::models::xgameruntime::xuser::{
+    MSATokenRequest, MSATokenResponse, XSTSTokenRequest, XSTSTokenResponse,
+};
 use xodus::proto::xodus::XodusMessageType;
 
 use crate::XML_MAGIC;
@@ -19,7 +21,13 @@ pub async fn handle(
     log::debug!("Reading buffer {message_size}");
     socket.read_exact(&mut buffer).await?;
     log::debug!("Read buffer");
-    let message_type = XodusMessageType::try_from(message_type as i32).unwrap_or_default();
+    let Ok(message_type) = XodusMessageType::try_from(message_type as i32) else {
+        // Answering `UNKNOWN + 1` would hand the client a PONG for a message we
+        // never understood, so reply as UNKNOWN instead and let it decide.
+        log::error!("Unknown message type {message_type}");
+        let data = super::encode_message(XML_MAGIC, XodusMessageType::Unknown as u16, vec![]);
+        return socket.write_all(&data).await;
+    };
 
     let out_buf = match parse_message(context, message_type, buffer).await {
         Ok(buf) => buf,
@@ -31,6 +39,94 @@ pub async fn handle(
 
     let data = super::encode_message(XML_MAGIC, message_type as u16 + 1, out_buf);
     socket.write_all(&data).await
+}
+
+/// Trades the stored user credentials for an Xbox Live XSTS token. Returns the
+/// ready-made Authorization header together with the identity it carries.
+async fn fetch_xbox_identity(
+    context: &mut SimpleContext,
+    client_id: &str,
+    relying_party: &str,
+) -> Result<Option<(String, String, String, i64)>, Box<dyn std::error::Error + Send + Sync>> {
+    let Token::Legacy(token) = context.tokens().get_user_sts_token()? else {
+        return Ok(None);
+    };
+    let Some(device_token) = context.device_token.clone() else {
+        return Ok(None);
+    };
+
+    let user_token = xodus::api::live::exchange_user_token(
+        &context.client,
+        token,
+        "USERNAME".to_string(),
+        device_token,
+        None,
+        Some("Silent".to_string()),
+        client_id.to_string(),
+        &[
+            (
+                // MBI_SSL is rejected for these stored credentials; the signin scope
+                // yields a "d=" compact token, which is the RPS ticket form that
+                // user.auth.xboxlive.com accepts.
+                format!("scope=xboxlive.signin&api-version=2.0&clientid={client_id}"),
+                Some(soap::PolicyReference::token_broker()),
+            ),
+            ("http://Passport.NET/tb".to_string(), None),
+        ],
+    )
+    .await?;
+
+    let ExchangeUserTokenOutcome::Issued(
+        soap::BodyContent::RequestSecurityTokenResponseCollection(mut collection),
+    ) = user_token
+    else {
+        log::error!("No token collection for the Xbox user authentication");
+        return Ok(None);
+    };
+
+    // The collection carries the DA token last and the usable compact ticket first.
+    if let Some(da) = collection.security_tokens.pop() {
+        let address = da.applies_to.endpoint_reference.address.clone();
+        let da: Token = da.into();
+        let address = if let Token::Legacy(legacy) = &da {
+            legacy.key_name.clone().unwrap_or(address)
+        } else {
+            address
+        };
+        if let Err(err) = context.tokens().save_user_token(address, da) {
+            log::warn!("Failed to persist refreshed STS token: {err}");
+        }
+    }
+
+    if collection.security_tokens.is_empty() {
+        log::error!("Token collection held no usable ticket");
+        return Ok(None);
+    }
+    let token: Token = collection.security_tokens.remove(0).into();
+    let Token::Compact(rps_ticket) = token else {
+        log::error!("Expected a compact RPS ticket, got {token:?}");
+        return Ok(None);
+    };
+
+    let xbox_user =
+        xodus::api::xbox::auth::authenticate_xbox_user(&context.client, rps_ticket).await?;
+    let xsts = xodus::api::xbox::auth::request_xsts_token(
+        &context.client,
+        xbox_user.token.clone(),
+        relying_party,
+    )
+    .await?;
+
+    let expiry = xsts.not_after.timestamp();
+    let xuid = xsts.xuid().unwrap_or_default().to_string();
+    let gamertag = xsts.gamertag().unwrap_or_default().to_string();
+
+    Ok(Some((
+        xodus::api::xbox::auth::get_xsts_auth_header(xsts),
+        xuid,
+        gamertag,
+        expiry,
+    )))
 }
 
 pub async fn parse_message(
@@ -113,9 +209,42 @@ pub async fn parse_message(
                     let Token::Compact(user_token) = token else {
                         return Ok(vec![]);
                     };
+                    // Same trip also settles the Xbox Live identity, so the caller
+                    // gets a real XUID and a usable Authorization header instead of
+                    // having to invent them.
+                    let relying_party = req
+                        .relying_party
+                        .as_deref()
+                        .unwrap_or("http://xboxlive.com");
+                    let identity = match fetch_xbox_identity(
+                        context,
+                        &req.client_id,
+                        relying_party,
+                    )
+                    .await
+                    {
+                        Ok(identity) => identity,
+                        Err(err) => {
+                            log::warn!("Xbox identity unavailable: {err}");
+                            None
+                        }
+                    };
+
                     let payload = MSATokenResponse {
                         token: user_token,
                         expiry: expiry.timestamp(),
+                        xsts_token: identity
+                            .as_ref()
+                            .map(|(t, _, _, _)| t.clone())
+                            .unwrap_or_default(),
+                        xuid: identity
+                            .as_ref()
+                            .map(|(_, x, _, _)| x.clone())
+                            .unwrap_or_default(),
+                        gamertag: identity
+                            .as_ref()
+                            .map(|(_, _, g, _)| g.clone())
+                            .unwrap_or_default(),
                         device_expiry: ms_device_rps_token.as_ref().map(|(_, r)| *r).unwrap_or(0),
                         device_rps: ms_device_rps_token
                             .map(|(t, _)| t)
@@ -124,8 +253,106 @@ pub async fn parse_message(
                     let payload = quick_xml::se::to_string(&payload)?;
                     Ok(payload.as_bytes().to_vec())
                 }
-                _ => todo!("Error handling sill sucks"),
+                other => {
+                    // Faults and single-token responses are both reachable here
+                    // once the stored tokens go stale - an empty payload is how
+                    // the rest of this path already reports "no token for you".
+                    log::error!("User token exchange returned no token collection: {other:?}");
+                    Ok(vec![])
+                }
             }
+        }
+        XodusMessageType::XstsTokenRequest => {
+            let string_buf = std::str::from_utf8(&buffer)?;
+            log::debug!("XSTS request: {string_buf:?}");
+            let req = quick_xml::de::from_str::<XSTSTokenRequest>(string_buf)?;
+
+            let Token::Legacy(token) = context.tokens().get_user_sts_token()? else {
+                return Ok(vec![]);
+            };
+
+            // The Xbox user token needs a full-trust RPS ticket, the same one the
+            // MSA path asks for with MSAFullTrust set.
+            let device_token = context.device_token.as_ref().unwrap();
+            let user_token = xodus::api::live::exchange_user_token(
+                &context.client,
+                token,
+                "USERNAME".to_string(),
+                device_token.clone(),
+                None,
+                Some("Silent".to_string()),
+                req.client_id.clone(),
+                &[
+                    (
+                        // MBI_SSL is rejected for these stored credentials; the signin
+                        // scope yields a "d=" compact token, which is exactly the RPS
+                        // ticket form user.auth.xboxlive.com accepts.
+                        format!(
+                            "scope=xboxlive.signin&api-version=2.0&clientid={}",
+                            req.client_id
+                        ),
+                        Some(soap::PolicyReference::token_broker()),
+                    ),
+                    ("http://Passport.NET/tb".to_string(), None),
+                ],
+            )
+            .await?;
+
+            let ExchangeUserTokenOutcome::Issued(
+                soap::BodyContent::RequestSecurityTokenResponseCollection(mut collection),
+            ) = user_token
+            else {
+                log::error!("No token collection for the Xbox user authentication: {user_token:?}");
+                return Ok(vec![]);
+            };
+
+            // The collection carries the DA token last and the usable compact ticket
+            // first, the same way the MSA path takes them apart.
+            if let Some(da) = collection.security_tokens.pop() {
+                let address = da.applies_to.endpoint_reference.address.clone();
+                let da: Token = da.into();
+                let address = if let Token::Legacy(legacy) = &da {
+                    legacy.key_name.clone().unwrap_or(address)
+                } else {
+                    address
+                };
+                if let Err(err) = context.tokens().save_user_token(address, da) {
+                    log::warn!("Failed to persist refreshed STS token: {err}");
+                }
+            }
+
+            if collection.security_tokens.is_empty() {
+                log::error!("Token collection held no usable ticket");
+                return Ok(vec![]);
+            }
+            let token: Token = collection.security_tokens.remove(0).into();
+            let Token::Compact(rps_ticket) = token else {
+                log::error!("Expected a compact RPS ticket, got {token:?}");
+                return Ok(vec![]);
+            };
+
+            let xbox_user = xodus::api::xbox::auth::authenticate_xbox_user(
+                &context.client,
+                rps_ticket,
+            )
+            .await?;
+
+            let xsts = xodus::api::xbox::auth::request_xsts_token(
+                &context.client,
+                xbox_user.token.clone(),
+                &req.relying_party,
+            )
+            .await?;
+
+            let payload = XSTSTokenResponse {
+                expiry: xsts.not_after.timestamp(),
+                xuid: xsts.xuid().unwrap_or_default().to_string(),
+                gamertag: xsts.gamertag().unwrap_or_default().to_string(),
+                token: xodus::api::xbox::auth::get_xsts_auth_header(xsts),
+            };
+
+            let payload = quick_xml::se::to_string(&payload)?;
+            Ok(payload.as_bytes().to_vec())
         }
         _ => Err("Unimplemented".into()),
     }

--- a/crates/xodus-service/src/connection/xml.rs
+++ b/crates/xodus-service/src/connection/xml.rs
@@ -43,10 +43,27 @@ pub async fn handle(
 
 /// Trades the stored user credentials for an Xbox Live XSTS token. Returns the
 /// ready-made Authorization header together with the identity it carries.
+/// The proof key arrives as JSON text in the request; a malformed one is treated as
+/// absent so the exchange still yields an unsigned token rather than failing outright.
+fn parse_proof_key(raw: Option<&str>) -> Option<serde_json::Value> {
+    let raw = raw?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    match serde_json::from_str(raw) {
+        Ok(value) => Some(value),
+        Err(err) => {
+            log::warn!("Ignoring malformed ProofKey: {err}");
+            None
+        }
+    }
+}
+
 async fn fetch_xbox_identity(
     context: &mut SimpleContext,
     client_id: &str,
     relying_party: &str,
+    proof_key: Option<serde_json::Value>,
 ) -> Result<Option<(String, String, String, i64)>, Box<dyn std::error::Error + Send + Sync>> {
     let Token::Legacy(token) = context.tokens().get_user_sts_token()? else {
         return Ok(None);
@@ -109,7 +126,8 @@ async fn fetch_xbox_identity(
     };
 
     let xbox_user =
-        xodus::api::xbox::auth::authenticate_xbox_user(&context.client, rps_ticket).await?;
+        xodus::api::xbox::auth::authenticate_xbox_user(&context.client, rps_ticket, proof_key)
+            .await?;
     let xsts = xodus::api::xbox::auth::request_xsts_token(
         &context.client,
         xbox_user.token.clone(),
@@ -220,6 +238,7 @@ pub async fn parse_message(
                         context,
                         &req.client_id,
                         relying_party,
+                        parse_proof_key(req.proof_key.as_deref()),
                     )
                     .await
                     {
@@ -334,6 +353,7 @@ pub async fn parse_message(
             let xbox_user = xodus::api::xbox::auth::authenticate_xbox_user(
                 &context.client,
                 rps_ticket,
+                parse_proof_key(req.proof_key.as_deref()),
             )
             .await?;
 

--- a/crates/xodus-service/src/connection/xml.rs
+++ b/crates/xodus-service/src/connection/xml.rs
@@ -10,6 +10,41 @@ use xodus::proto::xodus::XodusMessageType;
 use crate::XML_MAGIC;
 use crate::simple_context::SimpleContext;
 
+
+/// Title ids travel as the hex string MicrosoftGame.Config uses.
+fn parse_title_id(value: Option<&str>) -> Option<u32> {
+    u32::from_str_radix(value?.trim(), 16).ok()
+}
+
+
+/// Identity tuple built from a token that carries the title's claim.
+async fn title_scoped_identity(
+    context: &mut SimpleContext,
+    client_id: &str,
+    title_id: u32,
+    relying_party: &str,
+) -> Result<Option<(String, String, String, i64)>, Box<dyn std::error::Error + Send + Sync>> {
+    let Some(session) = context.title_session(client_id, title_id).await else {
+        return Ok(None);
+    };
+    let xsts = session
+        .xsts(relying_party)
+        .await
+        .map_err(|err| err.to_string())?;
+
+    let claims = xsts.display_claims.as_ref().and_then(|c| c.xui.first());
+    let xuid = claims.and_then(|x| x.get("xid").cloned()).unwrap_or_default();
+    let gamertag = claims.and_then(|x| x.get("gtg").cloned()).unwrap_or_default();
+    let expiry = xsts.not_after.timestamp();
+
+    Ok(Some((
+        xodus::api::xbox::auth::xsts_auth_header(&xsts),
+        xuid,
+        gamertag,
+        expiry,
+    )))
+}
+
 pub async fn handle(
     socket: &mut tokio::net::UnixStream,
     context: &mut SimpleContext,
@@ -230,22 +265,59 @@ pub async fn parse_message(
                     // Same trip also settles the Xbox Live identity, so the caller
                     // gets a real XUID and a usable Authorization header instead of
                     // having to invent them.
-                    let relying_party = req
-                        .relying_party
-                        .as_deref()
-                        .unwrap_or("http://xboxlive.com");
-                    let identity = match fetch_xbox_identity(
-                        context,
-                        &req.client_id,
-                        relying_party,
-                        parse_proof_key(req.proof_key.as_deref()),
-                    )
-                    .await
-                    {
-                        Ok(identity) => identity,
-                        Err(err) => {
-                            log::warn!("Xbox identity unavailable: {err}");
-                            None
+                    // Titles name the service they are calling, not the relying
+                    // party Xbox knows it by, so the endpoint documents decide.
+                    let title_id = parse_title_id(req.title_id.as_deref());
+                    let (relying_party, from_title) = match req.relying_party.as_deref() {
+                        Some(named) => {
+                            context
+                                .relying_party_for(named, &req.client_id, title_id)
+                                .await
+                        }
+                        None => ("http://xboxlive.com".to_string(), false),
+                    };
+
+                    // Real consoles always present a token carrying the title's
+                    // claim, and services check it: PlayFab answers
+                    // "not valid for title N" without it, and a publisher's own
+                    // back end rejects it outright. Only the SISU flow puts it in.
+                    let _ = from_title;
+                    let title_scoped = match title_id {
+                        Some(title_id) => {
+                            match title_scoped_identity(
+                                context,
+                                &req.client_id,
+                                title_id,
+                                &relying_party,
+                            )
+                            .await
+                            {
+                                Ok(identity) => identity,
+                                Err(err) => {
+                                    log::warn!("Title-scoped token unavailable: {err}");
+                                    None
+                                }
+                            }
+                        }
+                        None => None,
+                    };
+
+                    let identity = if let Some(identity) = title_scoped {
+                        Some(identity)
+                    } else {
+                        match fetch_xbox_identity(
+                            context,
+                            &req.client_id,
+                            &relying_party,
+                            parse_proof_key(req.proof_key.as_deref()),
+                        )
+                        .await
+                        {
+                            Ok(identity) => identity,
+                            Err(err) => {
+                                log::warn!("Xbox identity unavailable: {err}");
+                                None
+                            }
                         }
                     };
 
@@ -357,10 +429,20 @@ pub async fn parse_message(
             )
             .await?;
 
+            // Titles name the service they are calling, not the relying party Xbox
+            // knows it by, so the endpoint document decides which one to ask for.
+            let (relying_party, _) = context
+                .relying_party_for(
+                    &req.relying_party,
+                    &req.client_id,
+                    parse_title_id(req.title_id.as_deref()),
+                )
+                .await;
+
             let xsts = xodus::api::xbox::auth::request_xsts_token(
                 &context.client,
                 xbox_user.token.clone(),
-                &req.relying_party,
+                &relying_party,
             )
             .await?;
 

--- a/crates/xodus-service/src/simple_context.rs
+++ b/crates/xodus-service/src/simple_context.rs
@@ -3,12 +3,22 @@
 use std::sync::Arc;
 
 use xodus::models::secrets::LegacyToken;
+use xodus::api::xbox::title::TitleSession;
+use xodus::models::xbox::TitleMgtResponse;
 use xodus::tokens::TokenManager;
 
 pub struct SimpleContext {
     pub client: reqwest::Client,
     pub device_token: Option<LegacyToken>,
     tokens: Arc<TokenManager>,
+    /// Endpoint documents that map a service URL to the relying party Xbox issues
+    /// tokens for. Fetched once each, since neither changes within a session. The
+    /// title-scoped one is where a publisher's own back ends live.
+    endpoints: Option<TitleMgtResponse>,
+    title_endpoints: Option<TitleMgtResponse>,
+    /// SISU is expensive, so the flow runs once and every relying party after the
+    /// first costs only an XSTS exchange.
+    title_session: Option<TitleSession>,
 }
 
 impl SimpleContext {
@@ -23,7 +33,88 @@ impl SimpleContext {
             client,
             device_token: Some(device_token),
             tokens,
+            endpoints: None,
+            title_endpoints: None,
+            title_session: None,
         }
+    }
+
+    /// Opens the title's SISU session on first use and hands it back afterwards.
+    pub async fn title_session(
+        &mut self,
+        client_id: &str,
+        title_id: u32,
+    ) -> Option<&mut TitleSession> {
+        if self.title_session.is_none() {
+            match TitleSession::open(&self.client, &self.tokens, client_id, title_id).await {
+                Ok(session) => self.title_session = Some(session),
+                Err(err) => {
+                    log::warn!("Title session unavailable: {err}");
+                    return None;
+                }
+            }
+        }
+        self.title_session.as_mut()
+    }
+
+    /// Relying party to ask XSTS for when a caller names `url`. The title's own
+    /// document wins over the platform-wide one, because that is where a publisher
+    /// registers its back end. Anything neither document knows travels unchanged,
+    /// which is what callers that already hold a relying party rely on.
+    pub async fn relying_party_for(
+        &mut self,
+        url: &str,
+        client_id: &str,
+        title_id: Option<u32>,
+    ) -> (String, bool) {
+        if let Some(title_id) = title_id
+            && self.title_endpoints.is_none()
+        {
+            // reqwest::Client is a handle around shared state, so cloning it here
+            // just sidesteps holding two borrows of self at once.
+            let client = self.client.clone();
+            let fetched = match self.title_session(client_id, title_id).await {
+                Some(session) => {
+                    xodus::api::xbox::title::get_title_endpoints(&client, session).await
+                }
+                None => Err("no title session".into()),
+            };
+            match fetched {
+                Ok(response) => {
+                    log::debug!("Title {title_id:#x} publishes {} endpoints", response.end_points.len());
+                    self.title_endpoints = Some(response);
+                }
+                Err(err) => log::warn!("Title endpoint document unavailable: {err}"),
+            }
+        }
+
+        if self.endpoints.is_none() {
+            match xodus::api::xbox::title::get_title_management(&self.client).await {
+                Ok(response) => self.endpoints = Some(response),
+                Err(err) => log::warn!("Endpoint document unavailable: {err}"),
+            }
+        }
+
+        for (from_title, document) in [
+            (true, self.title_endpoints.as_ref()),
+            (false, self.endpoints.as_ref()),
+        ]
+        .into_iter()
+        .filter_map(|(from_title, doc)| doc.map(|doc| (from_title, doc)))
+        {
+            let Some(endpoint) = xodus::api::xbox::title::get_endpoint(url, document) else {
+                continue;
+            };
+            // A listed host without a relying party needs no token of its own, so
+            // there is nothing better to say than what the caller asked for.
+            if let Some(party) = endpoint.relying_party.as_deref() {
+                log::debug!("{url} resolves to relying party {party}");
+                return (party.to_string(), from_title);
+            }
+        }
+
+        log::debug!("{url} is in no endpoint document, using it as-is");
+        (url.to_string(), false)
     }
 
     pub fn tokens(&self) -> &Arc<TokenManager> {

--- a/crates/xodus/proto/xodus/common.proto
+++ b/crates/xodus/proto/xodus/common.proto
@@ -8,4 +8,6 @@ enum XodusMessageType {
     PONG = 2;
     MSA_TOKEN_REQUEST=3;
     MSA_TOKEN_RESPONSE=4;
+    XSTS_TOKEN_REQUEST=5;
+    XSTS_TOKEN_RESPONSE=6;
 }

--- a/crates/xodus/src/api/xbox/auth.rs
+++ b/crates/xodus/src/api/xbox/auth.rs
@@ -5,6 +5,7 @@ use crate::models::xbox::{
 pub async fn authenticate_xbox_user(
     client: &reqwest::Client,
     rps_ticket: String,
+    proof_key: Option<serde_json::Value>,
 ) -> reqwest::Result<XstsResponse> {
     let body = UserAuthRequest {
         relying_party: "http://auth.xboxlive.com".to_string(),
@@ -13,6 +14,7 @@ pub async fn authenticate_xbox_user(
             auth_method: "RPS".to_string(),
             site_name: "user.auth.xboxlive.com".to_string(),
             rps_ticket,
+            proof_key,
         },
     };
 

--- a/crates/xodus/src/api/xbox/auth.rs
+++ b/crates/xodus/src/api/xbox/auth.rs
@@ -62,3 +62,17 @@ pub fn get_xsts_auth_header(xsts: XstsResponse) -> String {
     let uhs = xsts.user_hash().expect("XSTS response missing xui claim");
     format!("XBL3.0 x={uhs};{}", xsts.token)
 }
+
+/// Same header shape as `get_xsts_auth_header`, for the xal-typed responses the
+/// title-scoped flow produces.
+pub fn xsts_auth_header(
+    xsts: &xal::response::XTokenResponse<xal::response::XSTSDisplayClaims>,
+) -> String {
+    let uhs = xsts
+        .display_claims
+        .as_ref()
+        .and_then(|claims| claims.xui.first())
+        .and_then(|xui| xui.get("uhs").cloned())
+        .unwrap_or_default();
+    format!("XBL3.0 x={uhs};{}", xsts.token)
+}

--- a/crates/xodus/src/api/xbox/mod.rs
+++ b/crates/xodus/src/api/xbox/mod.rs
@@ -49,7 +49,7 @@ pub async fn run(
         eprintln!("Unsupported token");
         panic!("TODO");
     };
-    let resp = authenticate_xbox_user(client, user_token)
+    let resp = authenticate_xbox_user(client, user_token, None)
         .await
         .expect("Failed to authenticate Xbox user");
 

--- a/crates/xodus/src/api/xbox/title.rs
+++ b/crates/xodus/src/api/xbox/title.rs
@@ -29,6 +29,105 @@ pub fn get_endpoint<'a>(url: &str, response: &'a TitleMgtResponse) -> Option<&'a
         .copied()
 }
 
+
+/// Endpoint document scoped to one title. Publishers register their own back ends
+/// here, and this is the only place those relying parties are published - the
+/// default document only ever describes Microsoft's own services.
+///
+/// The route needs a token carrying the title's claim, so this runs a SISU flow for
+/// the title first. Note it rejects the `type` query the default document requires.
+/// One SISU flow per title, kept so every relying party after the first costs a
+/// single XSTS exchange. Redoing SISU per token made sign-in slow enough that
+/// titles gave up and retried before the first one landed.
+pub struct TitleSession {
+    auth: xal::XalAuthenticator,
+    sisu: xal::response::SisuRPSAuthorizationResponse,
+    device: xal::response::DeviceToken,
+}
+
+impl TitleSession {
+    pub async fn open(
+        client: &reqwest::Client,
+        tokens: &crate::tokens::TokenManager,
+        client_id: &str,
+        title_id: u32,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let (auth, sisu, device) =
+            crate::auth::do_sisu(client, tokens, client_id, title_id as i64).await?;
+        Ok(Self { auth, sisu, device })
+    }
+
+    /// XSTS token carrying the title's claim, which is what PlayFab and a
+    /// publisher's own back end check before they trust the caller.
+    pub async fn xsts(
+        &mut self,
+        relying_party: &str,
+    ) -> Result<xal::response::XTokenResponse<xal::response::XSTSDisplayClaims>, Box<dyn std::error::Error>>
+    {
+        Ok(self
+            .auth
+            .get_xsts_token(
+                Some(&self.device),
+                Some(&self.sisu.title_token),
+                Some(&self.sisu.user_token),
+                relying_party,
+            )
+            .await?)
+    }
+}
+
+/// Endpoint document scoped to one title. Publishers register their own back ends
+/// here, and this is the only place those relying parties are published - the
+/// default document only ever describes Microsoft's own services.
+///
+/// The route needs a token carrying the title's claim, so this runs a SISU flow for
+/// the title first. Note it rejects the `type` query the default document requires.
+/// XSTS token carrying the title's claim, which is what a publisher's own back end
+/// checks before it trusts the caller. Xbox mints these only through a SISU flow for
+/// the title, so a plain user token is not enough.
+pub async fn title_scoped_xsts(
+    client: &reqwest::Client,
+    tokens: &crate::tokens::TokenManager,
+    client_id: &str,
+    title_id: u32,
+    relying_party: &str,
+) -> Result<xal::response::XTokenResponse<xal::response::XSTSDisplayClaims>, Box<dyn std::error::Error>>
+{
+    let (mut auth, sisu, device) =
+        crate::auth::do_sisu(client, tokens, client_id, title_id as i64).await?;
+
+    Ok(auth
+        .get_xsts_token(
+            Some(&device),
+            Some(&sisu.title_token),
+            Some(&sisu.user_token),
+            relying_party,
+        )
+        .await?)
+}
+
+/// Endpoint document scoped to one title. Publishers register their own back ends
+/// here, and this is the only place those relying parties are published - the
+/// default document only ever describes Microsoft's own services.
+///
+/// Note the route rejects the `type` query the default document requires.
+pub async fn get_title_endpoints(
+    client: &reqwest::Client,
+    session: &mut TitleSession,
+) -> Result<TitleMgtResponse, Box<dyn std::error::Error>> {
+    let xsts = session.xsts("http://xboxlive.com").await?;
+
+    let response = client
+        .get("https://title.mgt.xboxlive.com/titles/current/endpoints")
+        .header("x-xbl-contract-version", "1")
+        .header("Authorization", crate::api::xbox::auth::xsts_auth_header(&xsts))
+        .send()
+        .await?
+        .error_for_status()?;
+
+    Ok(response.json().await?)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/xodus/src/models/xbox.rs
+++ b/crates/xodus/src/models/xbox.rs
@@ -55,6 +55,21 @@ impl XstsResponse {
             .first()
             .map(|claim| claim.uhs.as_str())
     }
+
+    /// The XUID, when the relying party is allowed to see it.
+    pub fn xuid(&self) -> Option<&str> {
+        self.display_claims
+            .xui
+            .first()
+            .and_then(|claim| claim.xid.as_deref())
+    }
+
+    pub fn gamertag(&self) -> Option<&str> {
+        self.display_claims
+            .xui
+            .first()
+            .and_then(|claim| claim.gtg.as_deref())
+    }
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/xodus/src/models/xbox.rs
+++ b/crates/xodus/src/models/xbox.rs
@@ -16,6 +16,12 @@ pub struct UserAuthProperties {
     pub auth_method: String,
     pub site_name: String,
     pub rps_ticket: String,
+
+    /// JWK of the caller's ECDSA P-256 public key. Xbox binds the issued token to it,
+    /// and every request signed with the matching private key can then be verified.
+    /// Titles that check request signatures reject tokens issued without one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proof_key: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/crates/xodus/src/models/xbox.rs
+++ b/crates/xodus/src/models/xbox.rs
@@ -110,6 +110,8 @@ pub struct XstsRequest {
 #[serde(rename_all = "PascalCase")]
 pub struct TitleMgtResponse {
     pub end_points: Vec<TitleMgtEndPoint>,
+    /// Title-scoped documents list endpoints only, so this is absent there.
+    #[serde(default)]
     pub signature_policies: Vec<TitleMgtSignaturePolicy>,
 }
 

--- a/crates/xodus/src/models/xgameruntime/xuser.rs
+++ b/crates/xodus/src/models/xgameruntime/xuser.rs
@@ -17,6 +17,10 @@ pub struct MSATokenRequest {
     /// titles that verify signatures reject tokens issued without one.
     #[serde(default)]
     pub proof_key: Option<String>,
+    /// Title the caller runs as, in hex, from its MicrosoftGame.Config. Needed to
+    /// look up the endpoint document that names the title's own relying parties.
+    #[serde(default)]
+    pub title_id: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -47,6 +51,10 @@ pub struct XSTSTokenRequest {
     /// JWK of the caller's ECDSA P-256 public key, as JSON. See MSATokenRequest.
     #[serde(default)]
     pub proof_key: Option<String>,
+    /// Title the caller runs as, in hex, from its MicrosoftGame.Config. Needed to
+    /// look up the endpoint document that names the title's own relying parties.
+    #[serde(default)]
+    pub title_id: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/crates/xodus/src/models/xgameruntime/xuser.rs
+++ b/crates/xodus/src/models/xgameruntime/xuser.rs
@@ -12,6 +12,11 @@ pub struct MSATokenRequest {
     /// "http://xboxlive.com" when the caller does not care.
     #[serde(default)]
     pub relying_party: Option<String>,
+    /// JWK of the caller's ECDSA P-256 public key, as JSON. Xbox binds the issued
+    /// token to it so the caller can sign requests with the matching private key;
+    /// titles that verify signatures reject tokens issued without one.
+    #[serde(default)]
+    pub proof_key: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -39,6 +44,9 @@ pub struct XSTSTokenRequest {
     pub relying_party: String,
     /// Same MSA app id the title uses for its token requests.
     pub client_id: String,
+    /// JWK of the caller's ECDSA P-256 public key, as JSON. See MSATokenRequest.
+    #[serde(default)]
+    pub proof_key: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/crates/xodus/src/models/xgameruntime/xuser.rs
+++ b/crates/xodus/src/models/xgameruntime/xuser.rs
@@ -8,6 +8,10 @@ pub struct MSATokenRequest {
     pub allow_ui: bool,
     #[serde(default, alias = "MSAFullTrust")]
     pub msa_full_trust: bool,
+    /// Xbox Live relying party the caller needs a token for. Defaults to
+    /// "http://xboxlive.com" when the caller does not care.
+    #[serde(default)]
+    pub relying_party: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -17,4 +21,34 @@ pub struct MSATokenResponse {
     pub expiry: i64,
     pub device_rps: String,
     pub device_expiry: i64,
+    /// Xbox Live identity for the signed-in user. Empty when the XSTS exchange
+    /// could not be completed - the MSA token is still usable without it.
+    #[serde(default)]
+    pub xuid: String,
+    #[serde(default)]
+    pub gamertag: String,
+    /// Ready-to-use Authorization header ("XBL3.0 x=<uhs>;<token>").
+    #[serde(default)]
+    pub xsts_token: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct XSTSTokenRequest {
+    /// Service the caller wants a token for, e.g. "https://merged-nms-auth.nomanssky.com".
+    pub relying_party: String,
+    /// Same MSA app id the title uses for its token requests.
+    pub client_id: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct XSTSTokenResponse {
+    /// Ready-to-use Authorization header value ("XBL3.0 x=<uhs>;<token>").
+    pub token: String,
+    #[serde(default)]
+    pub xuid: String,
+    #[serde(default)]
+    pub gamertag: String,
+    pub expiry: i64,
 }


### PR DESCRIPTION
Titles that talk to their publisher's own back end could not sign in. That back end
checks two things we were not providing: that the token was issued for the relying
party Xbox registered for the service, and that it carries the title's claim.

We handed out a generic `http://xboxlive.com` token minted from the user alone, so:

- No Man's Sky's auth server answered **400** to every request
- PlayFab answered **"The Xbox token provided is not valid for title 306180"**

## Where those relying parties live

Only in the **title-scoped** endpoint document at `titles/current/endpoints`. Worth
recording, because none of it is obvious:

- The platform-wide `titles/default/endpoints?type=1` document (88 entries) contains no
  third-party host at all
- `titles/current/endpoints` needs a token carrying the title's claim; a plain user
  token gets **403**
- That route also **rejects** the `type` query the default document requires - with it
  you get 414

For No Man's Sky it answers:

```json
{"Host":"*.nomanssky.com","RelyingParty":"https://nomanssky.com/","TokenType":"JWT"}
```

`get_endpoint` already knew how to map a URL onto such a document, but nothing called it.

## What this changes

A caller may now name the service URL where a relying party goes. The title document
decides, falling back to the platform-wide one and then to the string unchanged, so
callers that already hold a relying party are unaffected.

Tokens are minted through a SISU flow for the title. That flow runs **once per session**:
doing it per relying party made sign-in slow enough that No Man's Sky gave up and retried
before the first token landed, and sent PlayFab a null token.

`TitleMgtResponse::signature_policies` became optional because title-scoped documents
list endpoints only.

## Measured

| | before | after |
|---|---|---|
| `merged-nms-auth.nomanssky.com` | 400 | **200**, JWT returned |
| PlayFab `LoginWithXbox` | `InvalidXboxLiveToken` | **SessionTicket** |
| RV There Yet? | "could not sign in" | **signs in, reaches gameplay** |

Tested against Minecraft, No Man's Sky and RV There Yet? under WineGDK. The matching
xgameruntime side (the request URL now travels to the service, and the title id goes out
with it) is in Weather-OS/WineGDK.

No Man's Sky still stops at its own "press to begin" screen for an unrelated reason: it
posts to `qa-nms-auth` rather than the production host, chosen somewhere in its own data.
Its identity chain is complete.
