### PR TITLE
Update README about supported Rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The project structure is as follows.
 
 ### Prerequisites
 
-- Rust version supporting `edition = "2024"`
+- Latest stable Rust version
 - Right now CLI relies on wry and tao to show a login page. Consult https://docs.rs/wry/latest/wry/#platform-considerations
 - xodus-service relies on `protoc` to compile `proto/` definitions make sure to install it for your platform
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The project structure is as follows.
 
 ### Prerequisites
 
-- Latest stable Rust version
+- Rust version 1.98 or later
 - Right now CLI relies on wry and tao to show a login page. Consult https://docs.rs/wry/latest/wry/#platform-considerations
 - xodus-service relies on `protoc` to compile `proto/` definitions make sure to install it for your platform
 


### PR DESCRIPTION
To be able to use the newest stable Rust features, like the new range API (https://doc.rust-lang.org/std/range/index.html), the latest stable Rust compiler is required. I think it's useful to be able to use those latest features, so this change makes the compiler requirement explicit in the README.

I think it's not problematic to ask for the latest *stable* Rust compiler, because it can be easily downloaded via rustup. Also, the API added in a stable Rust compiler is guaranteed to keep existing in the next releases (it's not like nightly, where features are added and removed freely).