### PR TITLE
Resumable downloads, reclaimed install space, and the Xbox Live token chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,16 +370,16 @@ dependencies = [
  "const-oid 0.10.2",
  "der 0.7.10",
  "dsa",
- "ecdsa",
+ "ecdsa 0.16.9",
  "ed25519-dalek 2.2.0",
  "kryptering",
  "ml-dsa",
  "num-bigint-dig 0.8.6",
  "num-traits",
- "p256",
+ "p256 0.13.2",
  "p384",
  "p521",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "pkcs1",
  "pkcs8 0.10.2",
  "pkcs8 0.11.0",
@@ -941,6 +941,7 @@ checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
+ "getrandom 0.4.3",
  "hybrid-array",
  "num-traits",
  "rand_core 0.10.1",
@@ -1190,7 +1191,7 @@ dependencies = [
  "const-oid 0.9.6",
  "der_derive",
  "flagset",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -1201,6 +1202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -1393,7 +1395,7 @@ dependencies = [
  "num-bigint-dig 0.8.6",
  "num-traits",
  "pkcs8 0.10.2",
- "rfc6979",
+ "rfc6979 0.4.0",
  "sha2 0.10.9",
  "signature 2.2.0",
  "zeroize",
@@ -1435,9 +1437,24 @@ dependencies = [
  "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve 0.13.8",
- "rfc6979",
+ "rfc6979 0.4.0",
  "signature 2.2.0",
  "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1532,7 +1549,7 @@ dependencies = [
  "generic-array",
  "group 0.13.0",
  "hkdf",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1 0.7.3",
@@ -1549,9 +1566,11 @@ dependencies = [
  "base16ct 1.0.0",
  "crypto-bigint 0.7.5",
  "crypto-common 0.2.2",
+ "digest 0.11.3",
  "ff 0.14.0",
  "group 0.14.0",
  "hybrid-array",
+ "pem-rfc7468 1.0.0",
  "pkcs8 0.11.0",
  "rand_core 0.10.1",
  "sec1 0.8.1",
@@ -2960,7 +2979,7 @@ dependencies = [
  "des 0.9.0",
  "digest 0.10.7",
  "dsa",
- "ecdsa",
+ "ecdsa 0.16.9",
  "ed25519-dalek 2.2.0",
  "ed448-goldilocks",
  "generic-array",
@@ -2970,7 +2989,7 @@ dependencies = [
  "md-5",
  "ml-dsa",
  "ml-kem",
- "p256",
+ "p256 0.13.2",
  "p384",
  "p521",
  "pbkdf2",
@@ -3734,10 +3753,23 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
+ "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
- "primeorder",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -3746,9 +3778,9 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "ecdsa",
+ "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
- "primeorder",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
 ]
 
@@ -3759,9 +3791,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
 dependencies = [
  "base16ct 0.2.0",
- "ecdsa",
+ "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
- "primeorder",
+ "primeorder 0.13.6",
  "rand_core 0.6.4",
  "sha2 0.10.9",
 ]
@@ -3829,6 +3861,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -4032,12 +4073,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve 0.13.8",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -4476,6 +4544,16 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac 0.12.1",
  "subtle",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -5793,7 +5871,7 @@ dependencies = [
  "hex",
  "kryptering",
  "log",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "spki 0.7.3",
  "thiserror 2.0.19",
  "x509-cert",
@@ -6601,6 +6679,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6708,7 +6797,7 @@ dependencies = [
  "log",
  "nt-time",
  "oauth2",
- "p256",
+ "p256 0.13.2",
  "rand 0.8.7",
  "reqwest 0.11.27",
  "serde",
@@ -6741,6 +6830,7 @@ dependencies = [
  "num-bigint-dig 0.9.1",
  "num-integer",
  "num_enum",
+ "p256 0.14.0",
  "prost",
  "prost-build",
  "quick-xml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6881,6 +6881,7 @@ dependencies = [
 name = "xodus-service"
 version = "0.1.0"
 dependencies = [
+ "base64 0.23.1",
  "chrono",
  "env_logger",
  "log",

--- a/crates/msixvc/src/streaming.rs
+++ b/crates/msixvc/src/streaming.rs
@@ -47,14 +47,32 @@ impl<'t> HttpRead<'t> {
     where
         Progress: FnMut(u64, u64) + Send + 't,
     {
+        Self::open_at(client, url, 0, progress).await
+    }
+
+    /// Open the same remote file, but starting at `start`.
+    ///
+    /// Used to continue an interrupted download: a Range request returns the
+    /// total length in Content-Range, so `len` still describes the whole file
+    /// and only the bytes after `start` come down the wire.
+    pub async fn open_at<Progress>(
+        client: reqwest::Client,
+        url: impl Into<String>,
+        start: u64,
+        progress: Option<Progress>,
+    ) -> std::io::Result<Self>
+    where
+        Progress: FnMut(u64, u64) + Send + 't,
+    {
         let url = url.into();
-        let initial = open_http_stream(client.clone(), url.clone(), None).await?;
+        let initial =
+            open_http_stream(client.clone(), url.clone(), (start > 0).then_some(start)).await?;
 
         Ok(Self {
             client,
             url,
             len: initial.len,
-            pos: 0,
+            pos: start,
             pending_open: None,
             active: Some(ActiveHttpStream {
                 next_offset: initial.start,
@@ -237,15 +255,59 @@ where
         len: u64,
         cache_path: impl AsRef<std::path::Path>,
     ) -> std::io::Result<Self> {
+        Self::open(upstream, len, cache_path, 0).await
+    }
+
+    /// How much of `cache_path` can be trusted as an already-downloaded prefix.
+    ///
+    /// The cache is written strictly in order, and the length on disk only grows
+    /// once bytes are written, so the file length is the resume point. The last
+    /// megabyte is given up anyway: if the machine lost power or a drive was
+    /// pulled mid-write, that tail is the only part that could have reached the
+    /// filesystem's length without its data, and a megabyte is far cheaper to
+    /// fetch again than a corrupt package is to diagnose.
+    pub async fn resumable_prefix(cache_path: impl AsRef<std::path::Path>) -> u64 {
+        const MARGIN: u64 = 1024 * 1024;
+        match tokio::fs::metadata(cache_path.as_ref()).await {
+            Ok(meta) => meta.len().saturating_sub(MARGIN) / MARGIN * MARGIN,
+            Err(_) => 0,
+        }
+    }
+
+    /// Open with `resume_from` bytes already cached.
+    ///
+    /// `upstream` must be positioned at `resume_from`, because everything read
+    /// from it is appended to the cache at that point.
+    pub async fn open(
+        upstream: R,
+        len: u64,
+        cache_path: impl AsRef<std::path::Path>,
+        resume_from: u64,
+    ) -> std::io::Result<Self> {
         let cache_path = cache_path.as_ref();
 
-        let cache_writer = OpenOptions::new()
+        let mut cache_writer = OpenOptions::new()
             .create(true)
-            .truncate(true)
+            .truncate(resume_from == 0)
             .read(true)
             .write(true)
             .open(cache_path)
             .await?;
+        // Drop anything past the resume point, so the file length and
+        // `cached_len` cannot disagree.
+        //
+        // The cursor has to be moved there too. The write path skips its seek
+        // whenever `cache_write_pos` already matches `cached_len`, and a
+        // freshly opened file sits at 0 -- so without this the continued
+        // download overwrites the start of the cache instead of appending, and
+        // the file never grows past the resume point.
+        if resume_from > 0 {
+            use tokio::io::AsyncSeekExt;
+            cache_writer.set_len(resume_from).await?;
+            cache_writer
+                .seek(std::io::SeekFrom::Start(resume_from))
+                .await?;
+        }
         let cache_reader = OpenOptions::new().read(true).open(cache_path).await?;
 
         Ok(Self {
@@ -254,13 +316,13 @@ where
             pos: 0,
             cache_reader,
             cache_writer,
-            cached_len: 0,
+            cached_len: resume_from,
             pending_seek: None,
             pending_chunk: None,
             pending_chunk_offset: 0,
             cache_read_state: CacheReadState::Idle,
             cache_write_state: CacheWriteState::Idle,
-            cache_write_pos: 0,
+            cache_write_pos: resume_from,
             upstream_buf: vec![0u8; UPSTREAM_READ_CHUNK_SIZE],
         })
     }
@@ -506,6 +568,13 @@ where
             match self.as_mut().poll_fill_from_upstream(cx) {
                 Poll::Ready(Ok(true)) => continue,
                 Poll::Ready(Ok(false)) => {
+                    // Flushing the last chunk falls through to here without
+                    // rechecking, so an upstream that ends exactly when the
+                    // cache is complete is not a failure -- the bytes asked
+                    // for did arrive. Only a genuinely short read is.
+                    if self.cached_len >= target_end {
+                        continue;
+                    }
                     return Poll::Ready(Err(Error::new(
                         ErrorKind::UnexpectedEof,
                         "upstream ended before requested prefix was cached",
@@ -838,6 +907,74 @@ mod tests {
             .unwrap();
         let len = http.len();
         PrefixCacheFile::new(http, len, cache).await.unwrap()
+    }
+
+    /// 5 MiB, so the 1 MiB resume margin has something to bite on.
+    fn large_body() -> Vec<u8> {
+        (0..5 * 1024 * 1024).map(|i| (i % 251) as u8).collect()
+    }
+
+    #[tokio::test]
+    async fn an_interrupted_download_continues_where_it_stopped() {
+        let body = large_body();
+        let server = spawn_server(body.clone(), None, 0).await.unwrap();
+        let cache = cache_path("resume");
+
+        // A first attempt that stops part-way, as a closed lid or a killed
+        // process would leave it.
+        {
+            let mut file = open_cached_reader(&server, &cache).await;
+            let mut buf = vec![0u8; 3 * 1024 * 1024];
+            file.read_exact(&mut buf).await.unwrap();
+            assert_eq!(buf, body[..buf.len()]);
+        }
+
+        // The last megabyte is given up deliberately, so the resume point is
+        // behind what was actually written.
+        let resume = PrefixCacheFile::<tokio::fs::File>::resumable_prefix(&cache).await;
+        assert_eq!(resume, 2 * 1024 * 1024, "should round down by the margin");
+
+        let http = HttpRead::open_at(reqwest::Client::new(), &server.url, resume, Some(|_, _| {}))
+            .await
+            .unwrap();
+        let len = http.len();
+        assert_eq!(len, body.len() as u64, "a ranged open still knows the total");
+
+        let mut file = PrefixCacheFile::open(http, len, &cache, resume).await.unwrap();
+        let mut all = Vec::new();
+        file.read_to_end(&mut all).await.unwrap();
+
+        // The whole file, not a seam of duplicated or missing bytes at the
+        // resume point -- which is the only thing that matters here.
+        assert_eq!(all.len(), body.len());
+        assert_eq!(all, body);
+
+        // And the continuation really was a range request, rather than
+        // re-fetching from the start.
+        let ranges = server.request_ranges();
+        assert!(
+            ranges.last().unwrap().as_deref() == Some("bytes=2097152-"),
+            "expected a resume range, got {ranges:?}"
+        );
+        let _ = std::fs::remove_file(cache);
+    }
+
+    #[tokio::test]
+    async fn nothing_to_resume_from_is_zero() {
+        let missing = cache_path("absent");
+        assert_eq!(
+            PrefixCacheFile::<tokio::fs::File>::resumable_prefix(&missing).await,
+            0
+        );
+
+        // Below the margin there is nothing worth keeping either.
+        let tiny = cache_path("tiny");
+        std::fs::write(&tiny, vec![0u8; 1024]).unwrap();
+        assert_eq!(
+            PrefixCacheFile::<tokio::fs::File>::resumable_prefix(&tiny).await,
+            0
+        );
+        let _ = std::fs::remove_file(tiny);
     }
 
     #[tokio::test]

--- a/crates/msixvc/src/xvd.rs
+++ b/crates/msixvc/src/xvd.rs
@@ -157,6 +157,29 @@ impl<R: Write + Seek> Write for SyncSubstream<R> {
 
 struct XvdEncryptionInfo {
     encrypted_sections: Vec<EncryptedSectionInfo>,
+    tweak_cipher: Aes128,
+    data_cipher: Aes128,
+}
+
+impl XvdEncryptionInfo {
+    fn new(encrypted_sections: Vec<EncryptedSectionInfo>, full_key: &[u8; 32]) -> Self {
+        let mut tweak_key = [0u8; 16];
+        let mut data_key = [0u8; 16];
+        tweak_key.copy_from_slice(&full_key[..16]);
+        data_key.copy_from_slice(&full_key[16..]);
+
+        Self {
+            encrypted_sections,
+            tweak_cipher: Aes128::new((&tweak_key).into()),
+            data_cipher: Aes128::new((&data_key).into()),
+        }
+    }
+
+    fn section_at(&self, offset: u64) -> Option<&EncryptedSectionInfo> {
+        self.encrypted_sections
+            .iter()
+            .find(|s| offset >= s.section_offset && offset < s.section_offset + s.section_length)
+    }
 }
 
 // The gpt crate requires the device to implement Debug,
@@ -217,7 +240,53 @@ impl<R: Read + Seek> Read for XvdStream<R> {
             .map_err(|_| Error::new(ErrorKind::InvalidData, "remaining range too large"))?;
         let to_read = remaining.min(buf.len());
 
-        self.inner.read(&mut buf[..to_read])
+        let absolute = self.offset + current;
+
+        // Without a content key the caller can only be given whatever happens to
+        // be stored in the clear, which is how this stream behaved previously.
+        let Some(info) = self.encryption_info.as_ref() else {
+            return self.inner.read(&mut buf[..to_read]);
+        };
+        let Some(section) = info.section_at(absolute) else {
+            return self.inner.read(&mut buf[..to_read]);
+        };
+
+        // XTS operates on whole 4K pages, but callers read arbitrary ranges, so
+        // decrypt the page containing the request and hand back the slice of it
+        // that was actually asked for. Reads are clamped to a single page and
+        // the caller loops, which Read explicitly permits.
+        let offset_in_section = absolute - section.section_offset;
+        let page_in_section = offset_in_section / PAGE_SIZE as u64;
+        let offset_in_page = (offset_in_section % PAGE_SIZE as u64) as usize;
+        let page_start = section.section_offset + page_in_section * PAGE_SIZE as u64;
+
+        self.inner.seek(SeekFrom::Start(page_start))?;
+        let mut page = [0u8; PAGE_SIZE];
+        self.inner.read_exact(&mut page)?;
+
+        let data_unit = match &section.data_units {
+            Some(units) => *units.get(page_in_section as usize).ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    format!("missing data unit for page {page_in_section}"),
+                )
+            })?,
+            None => page_in_section as u32,
+        };
+        decrypt_page_xts(
+            &mut page,
+            Tweak::new(data_unit, section.header_id, section.vduid),
+            &info.tweak_cipher,
+            &info.data_cipher,
+        );
+
+        let available = PAGE_SIZE - offset_in_page;
+        let copied = to_read.min(available);
+        buf[..copied].copy_from_slice(&page[offset_in_page..offset_in_page + copied]);
+
+        // Leave the underlying stream where a plain read would have left it.
+        self.inner.seek(SeekFrom::Start(absolute + copied as u64))?;
+        Ok(copied)
     }
 }
 
@@ -277,7 +346,7 @@ pub struct XvdFile {
     user_data_offset: u64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EncryptedSectionInfo {
     section_offset: u64,
     section_length: u64,
@@ -624,13 +693,38 @@ impl XvdFile {
         &self,
         file: Reader,
         only_plain: bool,
+        full_key: Option<&[u8; 32]>,
     ) -> Result<HashMap<String, SegmentFile>, Box<dyn std::error::Error>>
     where
         Reader: AsyncRead + AsyncSeek + Unpin,
     {
         let drive_data_offset = self.drive_data_offset;
         let drive_size = self.header.drive_size;
+
+        // How much of the drive is stored in the clear. This is a PROPERTY OF THE
+        // PACKAGE, not of what we can read: `only_plain` callers use it below to
+        // decide which files are safe to describe without SegmentMetadata, so it
+        // must keep meaning "plaintext prefix" even when a key lets us read past
+        // it. Conflating it with the stream length silently disables that filter
+        // and lets encrypted-region files be reported as plaintext.
         let drive_plain_len = self.non_encrypted_prefix_len(drive_data_offset, drive_size);
+        let debug_ntfs = std::env::var_os("XODUS_DEBUG_NTFS").is_some();
+
+        // How much of the drive we can actually read. Classic packages keep their
+        // file table (GPT + NTFS metadata) inside an encrypted section, so with a
+        // content key the whole drive is mapped and decrypted on demand; without
+        // one the view stops at the plaintext prefix, which is why such packages
+        // used to die on EOF partway through the parse.
+        let (drive_len, drive_encryption) = match full_key {
+            Some(key) => (
+                drive_size,
+                Some(XvdEncryptionInfo::new(
+                    self.encrypted_section_infos.clone(),
+                    key,
+                )),
+            ),
+            None => (drive_plain_len, None),
+        };
 
         block_in_place(|| {
             let block_size = 4096;
@@ -638,11 +732,11 @@ impl XvdFile {
                 XvdStream {
                     inner: SyncIoBridge::new(file),
                     offset: drive_data_offset,
-                    end_offset: drive_data_offset + drive_plain_len,
-                    encryption_info: None,
+                    end_offset: drive_data_offset + drive_len,
+                    encryption_info: drive_encryption,
                 },
                 0,
-                drive_plain_len,
+                drive_len,
             );
 
             let gp = gpt::GptConfig::new()
@@ -669,16 +763,30 @@ impl XvdFile {
 
             let bridge = gp.take_device().into_inner().into_inner();
             let partition_offset = drive_data_offset + part_start;
-            let partition_plain_len = self.non_encrypted_prefix_len(partition_offset, part_len);
+            // Same reasoning as the drive above: the NTFS volume itself is inside
+            // the encrypted section, so it must be readable in full to be parsed.
+            let (partition_len, partition_encryption) = match full_key {
+                Some(key) => (
+                    part_len,
+                    Some(XvdEncryptionInfo::new(
+                        self.encrypted_section_infos.clone(),
+                        key,
+                    )),
+                ),
+                None => (
+                    self.non_encrypted_prefix_len(partition_offset, part_len),
+                    None,
+                ),
+            };
             let mut fs = SyncSubstream::new(
                 XvdStream {
                     inner: bridge,
                     offset: partition_offset,
-                    end_offset: partition_offset + partition_plain_len,
-                    encryption_info: None,
+                    end_offset: partition_offset + partition_len,
+                    encryption_info: partition_encryption,
                 },
                 0,
-                partition_plain_len,
+                partition_len,
             );
 
             let reports = collect_ntfs_stream_layouts(&mut fs)?;
@@ -699,7 +807,25 @@ impl XvdFile {
                     continue;
                 };
 
-                if only_plain && partition_offset + start >= drive_data_offset + drive_plain_len {
+                let beyond_plain =
+                    partition_offset + start >= drive_data_offset + drive_plain_len;
+
+                if debug_ntfs {
+                    eprintln!(
+                        "ntfs: {:<52} off={:<13} len={:<12} beyond_plain={} {}",
+                        report.path,
+                        partition_offset + start,
+                        report.value_length,
+                        beyond_plain,
+                        if only_plain && beyond_plain {
+                            "SKIPPED"
+                        } else {
+                            ""
+                        }
+                    );
+                }
+
+                if only_plain && beyond_plain {
                     continue;
                 }
 
@@ -949,7 +1075,31 @@ impl XvdFile {
                 min((page_in_section - page_start) * 4096, sfile.length),
                 sfile.length,
             );
-            i.read_exact(&mut page).await?;
+            // Not every source is padded out to a whole page. Classic packages
+            // extract their files at true length, so the last page is short;
+            // read what is there and zero the rest rather than treating a short
+            // tail as a truncated stream. XTS decrypts in 16-byte blocks with a
+            // per-page tweak, so a partial page still decrypts correctly for the
+            // bytes that exist.
+            let mut filled = 0;
+            while filled < PAGE_SIZE {
+                match i.read(&mut page[filled..]).await? {
+                    0 => break,
+                    got => filled += got,
+                }
+            }
+            if filled == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "stream ended at page {page_in_section} of {} ({page_start}+{page_count})",
+                        sfile.length
+                    ),
+                )
+                .into());
+            }
+            page[filled..].fill(0);
+
             let to_write = min(
                 PAGE_SIZE,
                 sfile.length as usize

--- a/crates/xodus-cli/src/commands/run.rs
+++ b/crates/xodus-cli/src/commands/run.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::os::fd::{AsFd, IntoRawFd};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use msixvc::models::xvd::PAGE_SIZE;
@@ -13,6 +13,7 @@ use rustix::io::{FdFlags, fcntl_getfd, fcntl_setfd};
 #[cfg(not(target_os = "linux"))]
 use tempfile::{tempdir, tempfile, tempfile_in};
 use tokio::fs::{File, OpenOptions};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::process::Command;
 use xodus::tokens::TokenManager;
 
@@ -142,20 +143,6 @@ pub async fn run(
         }
     }
 
-    // Classic files
-    if lfiles.is_empty() {
-        let sfiles = xvd
-            .parse_ntfs_segment_metadata(&mut file, !lfiles.is_empty())
-            .await
-            .expect("ok");
-        for (n, sfile) in &sfiles {
-            if sfile.length.div_ceil(PAGE_SIZE as u64) as usize != sfile.data_hashs.len() {
-                println!("{}: {} {}", n, sfile.offset, sfile.length);
-            }
-        }
-        lfiles.extend(sfiles);
-    }
-
     let license = get_license(
         client,
         tokens,
@@ -181,6 +168,21 @@ pub async fn run(
 
     let full_key = content_key.unpack(&key).expect("failed to unpack");
 
+    // Classic files
+    if lfiles.is_empty() {
+        let sfiles = xvd
+            .parse_ntfs_segment_metadata(&mut file, !lfiles.is_empty(), None)
+            .await
+            .expect("ok");
+        for (n, sfile) in &sfiles {
+            if sfile.length.div_ceil(PAGE_SIZE as u64) as usize != sfile.data_hashs.len() {
+                println!("{}: {} {}", n, sfile.offset, sfile.length);
+            }
+        }
+        lfiles.extend(sfiles);
+    }
+
+
     let mut fds = vec![];
 
     let (cleanup, mount_dir) = prepare(&lfiles).await;
@@ -195,9 +197,25 @@ pub async fn run(
 
         let mut i = File::open(&source_path).await.unwrap();
 
-        xvd.mount_mem_fd(&mut i, &mut game_exe, file.1, *full_key, |_, _| {})
-            .await
-            .unwrap();
+        // Which packages hand back an already-decrypted executable is decided by
+        // how their metadata described it, not by anything we can see here, so
+        // let the file itself say: a classic (NTFS-metadata) package extracts a
+        // plain PE image at its true length, while a SegmentMetadata package
+        // keeps page-aligned ciphertext. Decrypting an image that is already a
+        // PE turns it into garbage, which is how Asphalt Legends ended up
+        // failing with "invalid name" out of ShellExecuteEx.
+        let mut magic = [0u8; 2];
+        let plaintext = i.read_exact(&mut magic).await.is_ok() && &magic == b"MZ";
+        i.seek(std::io::SeekFrom::Start(0)).await.unwrap();
+
+        if plaintext {
+            println!("{} is already decrypted; mapping it as-is", file.0);
+            tokio::io::copy(&mut i, &mut game_exe).await.unwrap();
+        } else {
+            xvd.mount_mem_fd(&mut i, &mut game_exe, file.1, *full_key, |_, _| {})
+                .await
+                .unwrap();
+        }
 
         let stdf = game_exe.into_std().await;
 
@@ -209,8 +227,17 @@ pub async fn run(
     }
 
     let mut env_value = String::new();
-    let nt_prefix = out_absolute.to_string_lossy().replace("/", "\\");
-    let nt_prefix = nt_prefix.trim_end_matches('\\');
+
+    // The drive letter must be the one wine itself derives for these files.
+    // The launched executable is fine either way because we hand wine its NT
+    // path directly, but a title that spawns a helper of its own -- Asphalt
+    // starts Crashpad's handler -- resolves the path through wine's drive
+    // mappings. On a secondary drive that yields e.g. F:\..., which never
+    // matches a map keyed on Z:\mnt\..., so the child is loaded from the
+    // still-encrypted file on disk and fails ("crash server failed to launch").
+    // Mirror wine's rule: the longest matching dosdevices target wins.
+    let (nt_drive, nt_prefix) = wine_dos_path(&out_absolute);
+    let nt_prefix = nt_prefix.trim_end_matches('\\').to_owned();
 
     let mut nt_entry = None;
 
@@ -220,7 +247,7 @@ pub async fn run(
         }
 
         let nt_suffix = fd.0.trim_start_matches('\\');
-        let nt_path = format!("\\??\\Z:{}\\{}", nt_prefix, nt_suffix);
+        let nt_path = format!("\\??\\{}:{}\\{}", nt_drive, nt_prefix, nt_suffix);
         if let Some(exe) = &exe {
             if exe == fd.0 {
                 nt_entry = Some(nt_path)
@@ -229,8 +256,14 @@ pub async fn run(
             nt_entry = Some(nt_path)
         }
 
-        env_value.push_str(&format!("{}:\\??\\Z:{}\\{}", fd.1, nt_prefix, nt_suffix))
+        env_value.push_str(&format!(
+            "{}:\\??\\{}:{}\\{}",
+            fd.1, nt_drive, nt_prefix, nt_suffix
+        ))
     }
+
+    eprintln!("XODUS_MAP drive={} prefix={}", nt_drive, nt_prefix);
+    for e in env_value.split('|').take(4) { eprintln!("XODUS_MAP entry: {e}"); }
 
     let Some(nt_entry) = nt_entry else {
         eprintln!("Could not find .exe");
@@ -257,4 +290,55 @@ pub async fn run(
     cleanup().await;
 
     ExitCode::from(status.code().map(|c| c as u8).unwrap_or(0))
+}
+
+/// Resolves a unix path to the DOS drive letter and path wine would use for it.
+///
+/// Wine maps drives with symlinks under `$WINEPREFIX/dosdevices` and resolves a
+/// unix path through the *most specific* mapping covering it. Z: is normally the
+/// root mapping, so it wins only when nothing more specific matches.
+fn wine_dos_path(path: &Path) -> (char, String) {
+    let prefix = std::env::var("WINEPREFIX")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            PathBuf::from(std::env::var("HOME").unwrap_or_default()).join(".wine")
+        });
+
+    let mut best: Option<(char, PathBuf)> = None;
+    if let Ok(entries) = std::fs::read_dir(prefix.join("dosdevices")) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            // Drive links are exactly "c:"; "c::" is the matching device link.
+            let mut chars = name.chars();
+            let (Some(letter), Some(':'), None) = (chars.next(), chars.next(), chars.next()) else {
+                continue;
+            };
+            let Ok(target) = std::fs::canonicalize(entry.path()) else {
+                continue;
+            };
+            if !path.starts_with(&target) {
+                continue;
+            }
+            if best
+                .as_ref()
+                .is_none_or(|(_, t)| target.as_os_str().len() > t.as_os_str().len())
+            {
+                best = Some((letter, target));
+            }
+        }
+    }
+
+    let Some((letter, target)) = best else {
+        return ('Z', path.to_string_lossy().replace("/", "\\"));
+    };
+
+    let rest = path.strip_prefix(&target).unwrap_or(path);
+    let rest = rest.to_string_lossy().replace("/", "\\");
+    let rest = if rest.is_empty() {
+        String::new()
+    } else {
+        format!("\\{}", rest.trim_start_matches('\\'))
+    };
+    (letter.to_ascii_uppercase(), rest)
 }

--- a/crates/xodus-cli/src/commands/run.rs
+++ b/crates/xodus-cli/src/commands/run.rs
@@ -120,6 +120,7 @@ pub async fn run(
     wine: String,
     exe: Option<String>,
     market: Option<String>,
+    game_args: Vec<String>,
 ) -> ExitCode {
     let mut lfiles: HashMap<String, SegmentFile> = HashMap::new();
 
@@ -240,6 +241,7 @@ pub async fn run(
     let nt_prefix = nt_prefix.trim_end_matches('\\').to_owned();
 
     let mut nt_entry = None;
+    let mut nt_entry_fd = None;
 
     for fd in fds {
         if !env_value.is_empty() {
@@ -250,10 +252,12 @@ pub async fn run(
         let nt_path = format!("\\??\\{}:{}\\{}", nt_drive, nt_prefix, nt_suffix);
         if let Some(exe) = &exe {
             if exe == fd.0 {
-                nt_entry = Some(nt_path)
+                nt_entry = Some(nt_path);
+                nt_entry_fd = Some(fd.1);
             }
         } else if nt_entry.is_none() {
-            nt_entry = Some(nt_path)
+            nt_entry = Some(nt_path);
+            nt_entry_fd = Some(fd.1);
         }
 
         env_value.push_str(&format!(
@@ -265,13 +269,28 @@ pub async fn run(
     eprintln!("XODUS_MAP drive={} prefix={}", nt_drive, nt_prefix);
     for e in env_value.split('|').take(4) { eprintln!("XODUS_MAP entry: {e}"); }
 
-    let Some(nt_entry) = nt_entry else {
+    let Some(mut nt_entry) = nt_entry else {
         eprintln!("Could not find .exe");
         return ExitCode::FAILURE;
     };
 
+    // EXPERIMENT (XODUS_EXE_VIA_PROC=1): name the memfd by path instead of
+    // handing wine an fd through WINE_DLL_FILE_MAP.
+    //
+    // /proc/self/fd/N is an ordinary openable path, and the fd is inherited, so
+    // any wine -- including a stock Proton -- could map the image from it with
+    // no patch at all. The plaintext still only ever exists in the memfd, so
+    // nothing reaches the filesystem either way.
+    if std::env::var("XODUS_EXE_VIA_PROC").is_ok() {
+        if let Some(fd) = nt_entry_fd {
+            nt_entry = format!("\\??\\Z:\\proc\\self\\fd\\{fd}");
+            eprintln!("XODUS_EXE_VIA_PROC: launching {nt_entry}");
+        }
+    }
+
     let mut wn = Command::new(wine)
         .arg(nt_entry)
+        .args(&game_args)
         .env("WINE_DLL_FILE_MAP", env_value)
         .spawn()
         .unwrap();

--- a/crates/xodus-cli/src/commands/run.rs
+++ b/crates/xodus-cli/src/commands/run.rs
@@ -254,7 +254,7 @@ pub async fn run(
     fds.sort_by(|a, b| a.0.cmp(b.0));
 
     if exe.is_none() {
-        if let Some(chosen) = auto_entry( &fds ) {
+        if let Some(chosen) = auto_entry(&fds, manifest_entry(out).as_deref()) {
             eprintln!("XODUS_AUTO_EXE {chosen}");
             exe = Some(chosen);
         }
@@ -335,7 +335,34 @@ pub async fn run(
 /// missing. Any of those will start, and none of them is the game, so the
 /// choice is made on what the file is rather than on whichever one the
 /// filesystem happened to yield first.
-fn auto_entry(fds: &[(&String, std::os::fd::RawFd)]) -> Option<String> {
+/// The executable an MSIX package's manifest declares.
+///
+/// `<Application Executable="...">` is the package saying which of its binaries
+/// is the application, which beats anything that can be inferred from the file
+/// names beside it.
+fn manifest_entry(dir: &Path) -> Option<String> {
+    let xml = std::fs::read_to_string(dir.join("appxmanifest.xml")).ok()?;
+    // "<Applications>" wraps the element and shares its prefix, so require the
+    // whitespace that separates the tag from its first attribute.
+    let app = xml.match_indices("<Application").find(|(i, _)| {
+        xml[i + "<Application".len()..]
+            .chars()
+            .next()
+            .is_some_and(char::is_whitespace)
+    })?.0;
+    let rest = &xml[app..];
+    // Stay within this element: a later one's attribute is not this one's.
+    let end = rest.find('>').unwrap_or(rest.len());
+    let attr = rest[..end].find("Executable=\"")?;
+    let value = &rest[attr + "Executable=\"".len()..end];
+    let value = &value[..value.find('"')?];
+    if value.is_empty() {
+        return None;
+    }
+    Some(value.replace('/', "\\"))
+}
+
+fn auto_entry(fds: &[(&String, std::os::fd::RawFd)], declared: Option<&str>) -> Option<String> {
     let mut best: Option<(u8, &String)> = None;
 
     for (path, _) in fds {
@@ -359,8 +386,23 @@ fn auto_entry(fds: &[(&String, std::os::fd::RawFd)]) -> Option<String> {
 
         // Unreal names its real binary <Project>-<Platform>-Shipping.exe; the
         // bare <Project>.exe beside it is a launcher shim, which on Subnautica 2
-        // is the one that reports a missing redistributable.
-        let rank = if name.ends_with("-shipping.exe") { 0 } else { 1 };
+        // is the one that reports a missing redistributable. That shim is also
+        // what the manifest names -- Expedition 33 declares SandFall.exe while
+        // the game is SandFall-WinGDK-Shipping.exe -- so the shipping binary
+        // outranks the declaration rather than the other way round.
+        //
+        // Below that, what the package declares beats sorting names: Hades II
+        // ships F10.exe beside Hades2.exe, and picking the first alphabetically
+        // started a helper that exits without ever opening a window.
+        let declared_name = declared
+            .map(|d| d.rsplit(['\\', '/']).next().unwrap_or(d).to_ascii_lowercase());
+        let rank = if name.ends_with("-shipping.exe") {
+            0
+        } else if declared_name.is_some_and(|d| d == name) {
+            1
+        } else {
+            2
+        };
 
         if best.as_ref().is_none_or(|(best_rank, best_path)| {
             rank < *best_rank || (rank == *best_rank && path < best_path)
@@ -431,7 +473,7 @@ mod test {
         let owned: Vec<String> = names.iter().map(|n| n.to_string()).collect();
         let fds: Vec<(&String, std::os::fd::RawFd)> =
             owned.iter().enumerate().map(|(i, n)| (n, i as i32)).collect();
-        auto_entry(&fds)
+        auto_entry(&fds, None)
     }
 
     #[test]
@@ -489,5 +531,28 @@ mod test {
         // Nothing but helpers means there is no good answer; returning None
         // leaves the old first-entry behaviour rather than refusing to start.
         assert_eq!(pick(&["\\crashpad_handler.exe"]), None);
+    }
+
+    #[test]
+    fn the_manifest_breaks_a_tie_that_sorting_gets_wrong() {
+        // Hades II ships F10.exe beside Hades2.exe; alphabetical order picks the
+        // helper, which exits without opening a window.
+        let a = "\\hades-ii\\F10.exe".to_string();
+        let b = "\\hades-ii\\Hades2.exe".to_string();
+        let fds = vec![(&a, 3), (&b, 4)];
+        assert_eq!(auto_entry(&fds, None).as_deref(), Some(a.as_str()));
+        assert_eq!(auto_entry(&fds, Some("Hades2.exe")).as_deref(), Some(b.as_str()));
+    }
+
+    #[test]
+    fn a_shipping_binary_still_beats_what_the_manifest_declares() {
+        // Expedition 33 declares SandFall.exe, but that is the launcher shim.
+        let shim = "\\exp33\\SandFall.exe".to_string();
+        let real = "\\exp33\\Binaries\\WinGDK\\SandFall-WinGDK-Shipping.exe".to_string();
+        let fds = vec![(&shim, 3), (&real, 4)];
+        assert_eq!(
+            auto_entry(&fds, Some("SandFall.exe")).as_deref(),
+            Some(real.as_str())
+        );
     }
 }

--- a/crates/xodus-cli/src/commands/run.rs
+++ b/crates/xodus-cli/src/commands/run.rs
@@ -118,7 +118,7 @@ pub async fn run(
     tokens: &TokenManager,
     source: String,
     wine: String,
-    exe: Option<String>,
+    mut exe: Option<String>,
     market: Option<String>,
     game_args: Vec<String>,
 ) -> ExitCode {
@@ -184,7 +184,7 @@ pub async fn run(
     }
 
 
-    let mut fds = vec![];
+    let mut fds: Vec<(&String, std::os::fd::RawFd)> = vec![];
 
     let (cleanup, mount_dir) = prepare(&lfiles).await;
 
@@ -242,6 +242,23 @@ pub async fn run(
 
     let mut nt_entry = None;
     let mut nt_entry_fd = None;
+
+    // `lfiles` is a HashMap and Rust seeds its hasher afresh every process, so
+    // iteration order changed on every launch. With no --exe the first entry
+    // won, which meant a package with several executables started a *different*
+    // one each time: Subnautica 2 has four, so roughly one launch in four
+    // started the game and the rest opened crashpad_handler ("--initial-client-
+    // data or --pipe-name is required") or the prerequisite shim (which reports
+    // "Microsoft Visual C++ 2015-2022 Redistributable is required"). That is the
+    // whole of the "launches work on the second or third try" behaviour.
+    fds.sort_by(|a, b| a.0.cmp(b.0));
+
+    if exe.is_none() {
+        if let Some(chosen) = auto_entry( &fds ) {
+            eprintln!("XODUS_AUTO_EXE {chosen}");
+            exe = Some(chosen);
+        }
+    }
 
     for fd in fds {
         if !env_value.is_empty() {
@@ -311,6 +328,50 @@ pub async fn run(
     ExitCode::from(status.code().map(|c| c as u8).unwrap_or(0))
 }
 
+/// Which executable to start when the caller did not name one.
+///
+/// A game package ships more than the game: a crash handler, a crash reporter,
+/// sometimes a prerequisite installer that only knows how to say what is
+/// missing. Any of those will start, and none of them is the game, so the
+/// choice is made on what the file is rather than on whichever one the
+/// filesystem happened to yield first.
+fn auto_entry(fds: &[(&String, std::os::fd::RawFd)]) -> Option<String> {
+    let mut best: Option<(u8, &String)> = None;
+
+    for (path, _) in fds {
+        let name = path
+            .rsplit(['\\', '/'])
+            .next()
+            .unwrap_or(path)
+            .to_ascii_lowercase();
+
+        // Helpers a title spawns for itself. Starting one directly does
+        // nothing useful and looks like a failed launch.
+        if name.contains("crashpad")
+            || name.contains("crashreport")
+            || name.contains("crashhandler")
+            || name.contains("prereqsetup")
+            || name.contains("webhelper")
+            || name.contains("subprocess")
+        {
+            continue;
+        }
+
+        // Unreal names its real binary <Project>-<Platform>-Shipping.exe; the
+        // bare <Project>.exe beside it is a launcher shim, which on Subnautica 2
+        // is the one that reports a missing redistributable.
+        let rank = if name.ends_with("-shipping.exe") { 0 } else { 1 };
+
+        if best.as_ref().is_none_or(|(best_rank, best_path)| {
+            rank < *best_rank || (rank == *best_rank && path < best_path)
+        }) {
+            best = Some((rank, path));
+        }
+    }
+
+    best.map(|(_, path)| path.clone())
+}
+
 /// Resolves a unix path to the DOS drive letter and path wine would use for it.
 ///
 /// Wine maps drives with symlinks under `$WINEPREFIX/dosdevices` and resolves a
@@ -360,4 +421,73 @@ fn wine_dos_path(path: &Path) -> (char, String) {
         format!("\\{}", rest.trim_start_matches('\\'))
     };
     (letter.to_ascii_uppercase(), rest)
+}
+
+#[cfg(test)]
+mod test {
+    use super::auto_entry;
+
+    fn pick(names: &[&str]) -> Option<String> {
+        let owned: Vec<String> = names.iter().map(|n| n.to_string()).collect();
+        let fds: Vec<(&String, std::os::fd::RawFd)> =
+            owned.iter().enumerate().map(|(i, n)| (n, i as i32)).collect();
+        auto_entry(&fds)
+    }
+
+    #[test]
+    fn the_game_is_chosen_over_its_helpers() {
+        // Subnautica 2's four executables. Picking by hash order started the
+        // crash handler or the prerequisite shim most of the time.
+        let chosen = pick(&[
+            "\\Subnautica2.exe",
+            "\\Subnautica2\\Binaries\\WinGDK\\Subnautica2-WinGDK-Shipping.exe",
+            "\\Subnautica2\\Plugins\\Sentry\\Binaries\\Win64\\crashpad_handler.exe",
+            "\\Engine\\Binaries\\Win64\\CrashReportClient.exe",
+        ]);
+        assert_eq!(
+            chosen.as_deref(),
+            Some("\\Subnautica2\\Binaries\\WinGDK\\Subnautica2-WinGDK-Shipping.exe")
+        );
+    }
+
+    #[test]
+    fn the_choice_does_not_depend_on_ordering() {
+        let forwards = pick(&[
+            "\\SandFall.exe",
+            "\\Sandfall\\Binaries\\WinGDK\\SandFall-WinGDK-Shipping.exe",
+            "\\Engine\\Binaries\\Win64\\CrashReportClient.exe",
+        ]);
+        let backwards = pick(&[
+            "\\Engine\\Binaries\\Win64\\CrashReportClient.exe",
+            "\\Sandfall\\Binaries\\WinGDK\\SandFall-WinGDK-Shipping.exe",
+            "\\SandFall.exe",
+        ]);
+        assert_eq!(forwards, backwards);
+        assert_eq!(
+            forwards.as_deref(),
+            Some("\\Sandfall\\Binaries\\WinGDK\\SandFall-WinGDK-Shipping.exe")
+        );
+    }
+
+    #[test]
+    fn unitys_crash_handler_is_a_helper_too() {
+        // Deep Rock Galactic Survivor ships exactly these two. The game only
+        // won the pick alphabetically, which is luck rather than a rule.
+        let chosen = pick(&["\\UnityCrashHandler64.exe", "\\DRG Survivor.exe"]);
+        assert_eq!(chosen.as_deref(), Some("\\DRG Survivor.exe"));
+    }
+
+    #[test]
+    fn a_title_without_a_shipping_binary_still_gets_the_game() {
+        // Minecraft ships one executable and a crash handler.
+        let chosen = pick(&["\\Minecraft.Windows.exe", "\\crashpad_handler.exe"]);
+        assert_eq!(chosen.as_deref(), Some("\\Minecraft.Windows.exe"));
+    }
+
+    #[test]
+    fn helpers_alone_are_better_than_nothing() {
+        // Nothing but helpers means there is no good answer; returning None
+        // leaves the old first-entry behaviour rather than refusing to start.
+        assert_eq!(pick(&["\\crashpad_handler.exe"]), None);
+    }
 }

--- a/crates/xodus-cli/src/commands/streaming.rs
+++ b/crates/xodus-cli/src/commands/streaming.rs
@@ -482,5 +482,67 @@ where
 
     std::fs::remove_file(&final_path).ok();
     std::fs::rename(&cache_path, &final_path).expect("ok");
+    reclaim_package_payload(&final_path);
     ExitCode::SUCCESS
+}
+
+/// Hand back the part of the installed package that nothing reads again.
+///
+/// The package is kept beside the extracted game because launching needs it:
+/// it carries the XVD header, the segment metadata and the content id the
+/// licence is fetched against. It does not carry anything else worth keeping.
+/// The ciphertext that gets decrypted at launch is read from the extracted
+/// files, so the payload sitting in the package is never touched again -- and
+/// it is what makes an install twice the size of the download. Hogwarts Legacy
+/// asks for 190GB where Steam asks for 90.
+///
+/// Measured across every package here, a launch reads one contiguous run from
+/// the start and stops: 7MB of 3.3GB for Deep Rock Galactic Survivor, 90MB of
+/// 44GB for Expedition 33, 19MB of 9.5GB for Asphalt Legends -- 0.2% in each
+/// case, through both the SegmentMetadata and the classic NTFS-metadata paths.
+///
+/// Punching the rest out rather than truncating keeps every offset in the file
+/// valid, so nothing above needs to learn a new layout: the file still reports
+/// its full length and reads back zeroes where the payload was. What is kept is
+/// 1% or 64MB, whichever is larger -- five times the most any package has
+/// needed, leaving room for one whose metadata runs longer than these.
+///
+/// A filesystem that cannot punch holes says so and keeps its blocks; that is
+/// worth a word to the caller but not a failed install.
+fn reclaim_package_payload(path: &Path) {
+    use rustix::fs::{FallocateFlags, fallocate};
+
+    let file = match std::fs::OpenOptions::new().write(true).open(path) {
+        Ok(file) => file,
+        Err(err) => {
+            eprintln!("could not open the package to reclaim its payload: {err}");
+            return;
+        }
+    };
+    let size = match file.metadata() {
+        Ok(meta) => meta.len(),
+        Err(err) => {
+            eprintln!("could not size the package: {err}");
+            return;
+        }
+    };
+
+    let keep = std::cmp::max(size / 100, 64 * 1024 * 1024);
+    if keep >= size {
+        return;
+    }
+
+    match fallocate(
+        &file,
+        FallocateFlags::PUNCH_HOLE | FallocateFlags::KEEP_SIZE,
+        keep,
+        size - keep,
+    ) {
+        Ok(()) => println!(
+            "reclaimed {} MiB from the package; {} MiB kept for launching",
+            (size - keep) / (1024 * 1024),
+            keep / (1024 * 1024)
+        ),
+        Err(err) => eprintln!("could not reclaim the package payload: {err}"),
+    }
 }

--- a/crates/xodus-cli/src/commands/streaming.rs
+++ b/crates/xodus-cli/src/commands/streaming.rs
@@ -268,44 +268,6 @@ where
         }
     }
 
-    if !try_skip_ntfs || rfiles.is_empty() {
-        tx.send(ProgressEvent::UpdateStatus {
-            name: "Downloading ntfs...".to_owned(),
-        })
-        .await
-        .ok();
-        let sfiles = remote_xvd
-            .parse_ntfs_segment_metadata(&mut remote_file, !rfiles.is_empty())
-            .await
-            .expect("ok");
-        rfiles.extend(sfiles);
-    }
-
-    let file = OpenOptions::new()
-        .read(true)
-        .open(final_path.to_owned())
-        .await
-        .ok();
-
-    if let Some(mut file) = file {
-        let xvd = XvdFile::parse(&mut file).await.expect("no err");
-
-        let files = xvd.parse_user_package_files(&mut file).await.expect("ok");
-        for (k, v) in &files {
-            if k == "SegmentMetadata.bin" {
-                let sfiles = xvd.parse_segment_metadata(&mut file, v).await.expect("ok");
-                lfiles = sfiles;
-            }
-        }
-
-        if let Ok(sfiles) = xvd
-            .parse_ntfs_segment_metadata(&mut file, !lfiles.is_empty())
-            .await
-        {
-            lfiles.extend(sfiles);
-        }
-    }
-
     let license = get_license(
         client,
         tokens,
@@ -330,6 +292,45 @@ where
     };
 
     let full_key = content_key.unpack(&key).expect("failed to unpack");
+
+    if !try_skip_ntfs || rfiles.is_empty() {
+        tx.send(ProgressEvent::UpdateStatus {
+            name: "Downloading ntfs...".to_owned(),
+        })
+        .await
+        .ok();
+        let sfiles = remote_xvd
+            .parse_ntfs_segment_metadata(&mut remote_file, !rfiles.is_empty(), Some(&full_key))
+            .await
+            .expect("ok");
+        rfiles.extend(sfiles);
+    }
+
+    let file = OpenOptions::new()
+        .read(true)
+        .open(final_path.to_owned())
+        .await
+        .ok();
+
+    if let Some(mut file) = file {
+        let xvd = XvdFile::parse(&mut file).await.expect("no err");
+
+        let files = xvd.parse_user_package_files(&mut file).await.expect("ok");
+        for (k, v) in &files {
+            if k == "SegmentMetadata.bin" {
+                let sfiles = xvd.parse_segment_metadata(&mut file, v).await.expect("ok");
+                lfiles = sfiles;
+            }
+        }
+
+        if let Ok(sfiles) = xvd
+            .parse_ntfs_segment_metadata(&mut file, !lfiles.is_empty(), Some(&full_key))
+            .await
+        {
+            lfiles.extend(sfiles);
+        }
+    }
+
 
     let total_size = rfiles
         .iter()

--- a/crates/xodus-cli/src/commands/streaming.rs
+++ b/crates/xodus-cli/src/commands/streaming.rs
@@ -40,6 +40,8 @@ pub async fn run(
     market: Option<String>,
 ) -> ExitCode {
     let (tx, rx) = tokio::sync::mpsc::channel::<ProgressEvent>(256);
+    // Only a network source can be resumed; a local file is already on disk.
+    let mut resume_from = 0u64;
     if source.starts_with("file://") {
         let fsrc = source.strip_prefix("file://").unwrap_or_default();
         let f = match File::open(fsrc).await {
@@ -56,7 +58,7 @@ pub async fn run(
                 return ExitCode::FAILURE;
             }
         };
-        run_cli_reader(
+        return run_cli_reader(
             client,
             tokens,
             destination,
@@ -68,6 +70,7 @@ pub async fn run(
             &source,
             &tx,
             rx,
+            0,
         )
         .await;
     } else {
@@ -112,10 +115,26 @@ pub async fn run(
             )
         };
         let url = &vurl;
-        let mut pos = 0;
-        let http_file = streaming::HttpRead::open(
+
+        // An interrupted download leaves its cache behind. Continue from there
+        // rather than starting over: these packages run to tens of gigabytes,
+        // and losing all of it to a closed lid or an unplugged drive is the
+        // difference between an inconvenience and an unusable installer.
+        std::fs::create_dir_all(&destination).ok();
+        let cache_path = Path::new(&destination).join(".xodus-streaming-tmp.msixvc");
+        resume_from = streaming::PrefixCacheFile::<File>::resumable_prefix(&cache_path).await;
+        if resume_from > 0 {
+            eprintln!(
+                "Continuing from {:.1} GB already downloaded",
+                resume_from as f64 / 1e9
+            );
+        }
+
+        let mut pos = resume_from;
+        let http_file = streaming::HttpRead::open_at(
             client.clone(),
             url,
+            resume_from,
             Some(|c, _| {
                 if tx
                     .try_send(ProgressEvent::Advanced {
@@ -132,7 +151,7 @@ pub async fn run(
         .expect("ok");
         let l = http_file.len();
 
-        run_cli_reader(
+        return run_cli_reader(
             client,
             tokens,
             destination,
@@ -144,11 +163,10 @@ pub async fn run(
             url,
             &tx,
             rx,
+            resume_from,
         )
         .await;
     }
-
-    ExitCode::SUCCESS
 }
 
 async fn run_cli_reader<Reader>(
@@ -163,7 +181,8 @@ async fn run_cli_reader<Reader>(
     url: &str,
     tx: &Sender<ProgressEvent>,
     mut rx: Receiver<ProgressEvent>,
-) -> ()
+    resume_from: u64,
+) -> ExitCode
 where
     Reader: AsyncRead + Unpin,
 {
@@ -221,6 +240,7 @@ where
         l,
         url,
         tx,
+        resume_from,
     )
     .await
 }
@@ -236,7 +256,8 @@ async fn run_reader<Reader>(
     l: u64,
     url: &str,
     tx: &Sender<ProgressEvent>,
-) -> ()
+    resume_from: u64,
+) -> ExitCode
 where
     Reader: AsyncRead + Unpin,
 {
@@ -247,9 +268,10 @@ where
     let cache_path = out.join(".xodus-streaming-tmp.msixvc");
     let final_path = out.join(".xodus-streaming.msixvc");
 
-    let mut remote_file = streaming::PrefixCacheFile::new(reader, l, cache_path.clone())
-        .await
-        .expect("no err");
+    let mut remote_file =
+        streaming::PrefixCacheFile::open(reader, l, cache_path.clone(), resume_from)
+            .await
+            .expect("no err");
     let remote_xvd = XvdFile::parse(&mut remote_file).await.expect("no err");
     let mut rfiles: HashMap<String, SegmentFile> = HashMap::new();
     let mut lfiles: HashMap<String, SegmentFile> = HashMap::new();
@@ -277,7 +299,7 @@ where
     .await;
     if let Err(err) = license {
         eprintln!("{}", err);
-        return;
+        return ExitCode::FAILURE;
     }
     let (key, game_splicense) = license.unwrap();
     if game_splicense.content_keys.len() != 1 {
@@ -285,10 +307,10 @@ where
             "unexpected number of content keys {}",
             game_splicense.content_keys.len()
         );
-        return;
+        return ExitCode::FAILURE;
     }
     let Some((_, content_key)) = game_splicense.content_keys.into_iter().next() else {
-        return;
+        return ExitCode::FAILURE;
     };
 
     let full_key = content_key.unpack(&key).expect("failed to unpack");
@@ -354,7 +376,7 @@ where
                 out.display(),
                 err
             );
-            return;
+            return ExitCode::FAILURE;
         }
     };
 
@@ -366,7 +388,7 @@ where
             available_free_space,
             total_size
         );
-        return;
+        return ExitCode::FAILURE;
     }
 
     tx.send(ProgressEvent::UpdateRemaining {
@@ -460,4 +482,5 @@ where
 
     std::fs::remove_file(&final_path).ok();
     std::fs::rename(&cache_path, &final_path).expect("ok");
+    ExitCode::SUCCESS
 }

--- a/crates/xodus-cli/src/main.rs
+++ b/crates/xodus-cli/src/main.rs
@@ -67,6 +67,14 @@ enum SubCommand {
         exe: Option<String>,
         #[arg(short, long)]
         market: Option<String>,
+        /// Arguments passed on to the game itself, after `--`.
+        ///
+        /// Titles routinely need these and there was no way to give them any.
+        /// Unreal Engine, for one, writes no log at all without `-log`, and its
+        /// log is the only place it explains decisions like whether DLSS is
+        /// available.
+        #[arg(last = true)]
+        game_args: Vec<String>,
     },
     #[command(about = "Generate or decrypt base64-encoded CLEP challenge data")]
     Clep {
@@ -197,7 +205,8 @@ async fn main() -> ExitCode {
             wine,
             exe,
             market,
-        } => commands::run::run(&client, &tokens, source, wine, exe, market).await,
+            game_args,
+        } => commands::run::run(&client, &tokens, source, wine, exe, market, game_args).await,
         SubCommand::Clep { action } => match action {
             ClepAction::Generate {
                 smbios,

--- a/crates/xodus-cli/src/package.rs
+++ b/crates/xodus-cli/src/package.rs
@@ -88,8 +88,9 @@ pub async fn get_packages(
         return Err(Box::new(std::io::Error::other("Unsupported user token")));
     };
 
-    let xsts_token =
-        xodus::api::xbox::run(client, dev_token, legacy, "http://update.xboxlive.com").await;
+    let xsts_token = xodus::api::xbox::run(client, dev_token, legacy, "http://update.xboxlive.com")
+        .await
+        .map_err(|err| std::io::Error::other(err.to_string()))?;
 
     let response = client
         .get(format!(

--- a/crates/xodus-service/Cargo.toml
+++ b/crates/xodus-service/Cargo.toml
@@ -13,3 +13,4 @@ log = "0.4.33"
 env_logger = "0.11.11"
 tokio-util = "0.7.19"
 serde_json = "1.0.151"
+base64 = { workspace = true }

--- a/crates/xodus-service/src/connection/router.rs
+++ b/crates/xodus-service/src/connection/router.rs
@@ -22,9 +22,14 @@ pub async fn route(
         if token.is_cancelled() {
             return;
         }
-        let read = socket.read_exact(&mut read_magic).await;
-        if let Err(err) = read {
-            log::error!("Failed to read magic: {err:?}");
+        if let Err(err) = socket.read_exact(&mut read_magic).await {
+            // One request per connection is the normal pattern for the Wine
+            // client, so end-of-stream here is a disconnect, not a failure.
+            if err.kind() == std::io::ErrorKind::UnexpectedEof {
+                log::debug!("Client from pid {cred:?} disconnected");
+            } else {
+                log::error!("Failed to read magic: {err:?}");
+            }
             return;
         }
 

--- a/crates/xodus-service/src/connection/xml.rs
+++ b/crates/xodus-service/src/connection/xml.rs
@@ -234,18 +234,53 @@ pub async fn parse_message(
             // Whether the token carries profile claims decides what the title
             // shows: without them XUserGetGamertag falls back to a placeholder,
             // and the player sees a stranger's name on their own save.
+            // Read the identity out before the header consumes the response.
+            // Whether the token carries profile claims decides what the title
+            // shows: without them XUserGetGamertag falls back to a placeholder.
+            let xuid = xsts.xuid().unwrap_or_default().to_string();
+            let gamertag = xsts.gamertag().unwrap_or_default().to_string();
+            let expiry = xsts.not_after.timestamp();
+            let token = xodus::api::xbox::get_xsts_auth_header(xsts);
+
+            // Sign the request the title is about to send.
+            //
+            // Xbox's endpoint table gives *.xboxlive.com a signature policy
+            // (version 1, ES256), and real-time activity enforces it: an
+            // unsigned connect to rta.xboxlive.com comes back 401, XSAPI
+            // retries in a loop, and a connect left in flight at shutdown stops
+            // libHttpClient's cleanup from ever completing -- which is what
+            // hangs the title on exit.
+            //
+            // The device proof key is the right one to sign with: it is the key
+            // the device token was issued against, so the service already knows
+            // it. An empty signature is still better than a wrong one, so a
+            // failure here is reported and left empty rather than guessed at.
+            let signature = match context.tokens().get_or_create_proof_key() {
+                Ok(proof_key) => {
+                    let method = if req.method.is_empty() { "GET" } else { &req.method };
+                    let path = if req.path_and_query.is_empty() { "/" } else { &req.path_and_query };
+                    let signature = proof_key.sign_request(method, path, &token, b"");
+                    log::debug!("signed {method} {path} for {relying_party}");
+                    signature
+                }
+                Err(err) => {
+                    log::error!("no proof key to sign {relying_party} with: {err}");
+                    String::new()
+                }
+            };
+
             log::debug!(
-                "XSTS token for {relying_party}: xuid {:?}, gamertag {:?}",
-                xsts.xuid(),
-                xsts.gamertag()
+                "XSTS token for {relying_party}: xuid {xuid:?}, gamertag {gamertag:?}, \
+                 signature {} bytes",
+                signature.len()
             );
 
             let payload = XstsTokenResponse {
-                expiry: xsts.not_after.timestamp(),
-                xuid: xsts.xuid().unwrap_or_default().to_string(),
-                gamertag: xsts.gamertag().unwrap_or_default().to_string(),
-                signature: String::new(),
-                token: xodus::api::xbox::get_xsts_auth_header(xsts),
+                expiry,
+                xuid,
+                gamertag,
+                signature,
+                token,
             };
             let payload = quick_xml::se::to_string(&payload)?;
             Ok(payload.as_bytes().to_vec())

--- a/crates/xodus-service/src/connection/xml.rs
+++ b/crates/xodus-service/src/connection/xml.rs
@@ -10,6 +10,30 @@ use xodus::proto::xodus::XodusMessageType;
 use crate::XML_MAGIC;
 use crate::simple_context::SimpleContext;
 
+/// App ids MSA has already refused a title-bound ticket for.
+///
+/// The refusal is a property of the app id and the account, not of the moment,
+/// so asking again only spends a sisu round trip to be told the same thing. It
+/// is deliberately not persisted: a title that becomes provisioned later should
+/// get another go on the next run.
+fn refused_title_tokens() -> &'static std::sync::Mutex<std::collections::HashSet<String>> {
+    static REFUSED: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<String>>> =
+        std::sync::OnceLock::new();
+    REFUSED.get_or_init(Default::default)
+}
+
+fn title_tokens_refused(app_id: &str) -> bool {
+    refused_title_tokens()
+        .lock()
+        .is_ok_and(|refused| refused.contains(app_id))
+}
+
+fn remember_title_tokens_refused(app_id: &str) {
+    if let Ok(mut refused) = refused_title_tokens().lock() {
+        refused.insert(app_id.to_string());
+    }
+}
+
 pub async fn handle(
     socket: &mut tokio::net::UnixStream,
     context: &mut SimpleContext,
@@ -186,6 +210,23 @@ pub async fn parse_message(
                             &relying_party,
                         )
                         .await?
+                    } else if title_tokens_refused(&req.app_id) {
+                        // Already learned this app id gets nothing from MSA.
+                        // Trying again costs a sisu round trip per token, and
+                        // a title that times out waiting gives up on the
+                        // request entirely -- which is how a signed connect
+                        // ends up never being made.
+                        log::debug!(
+                            "skipping the title-bound attempt for {}; MSA refused it earlier",
+                            req.app_id
+                        );
+                        xodus::api::xbox::run(
+                            &context.client,
+                            device_token.clone(),
+                            user_sts,
+                            &relying_party,
+                        )
+                        .await?
                     } else {
                         let proof_key = context.tokens().get_or_create_proof_key()?;
                         let device_id = context.tokens().get_or_create_device_id()?;
@@ -216,6 +257,7 @@ pub async fn parse_message(
                                      falling back to a user-only token",
                                     req.app_id
                                 );
+                                remember_title_tokens_refused(&req.app_id);
                                 xodus::api::xbox::run(
                                     &context.client,
                                     device_token.clone(),

--- a/crates/xodus-service/src/connection/xml.rs
+++ b/crates/xodus-service/src/connection/xml.rs
@@ -2,7 +2,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use xodus::models::live::ExchangeUserTokenOutcome;
 use xodus::models::secrets::Token;
 use xodus::models::soap;
-use xodus::models::xgameruntime::xuser::{MSATokenRequest, MSATokenResponse};
+use xodus::models::xgameruntime::xuser::{
+    MSATokenRequest, MSATokenResponse, XstsTokenRequest, XstsTokenResponse,
+};
 use xodus::proto::xodus::XodusMessageType;
 
 use crate::XML_MAGIC;
@@ -126,6 +128,108 @@ pub async fn parse_message(
                 }
                 _ => todo!("Error handling sill sucks"),
             }
+        }
+        XodusMessageType::XstsTokenRequest => {
+            let req = quick_xml::de::from_str::<XstsTokenRequest>(std::str::from_utf8(&buffer)?)?;
+            log::debug!(
+                "XSTS token requested for {} (force_refresh {})",
+                req.relying_party,
+                req.force_refresh
+            );
+
+            // XSTS tokens are good for hours; minting one per HTTP request would
+            // put a SOAP round trip in front of every call the title makes.
+            // The app id is part of the identity of the token, not just of the
+            // request: a token minted for one title is not usable by another.
+            let cache_key = if req.app_id.is_empty() {
+                req.relying_party.clone()
+            } else {
+                format!("{}#{}", req.relying_party, req.app_id)
+            };
+            let cached = if req.force_refresh {
+                None
+            } else {
+                context.tokens().get_cached_xsts(&cache_key)
+            };
+
+            let xsts = match cached {
+                Some(xsts) => {
+                    log::debug!("Serving {cache_key} from cache");
+                    xsts
+                }
+                None => {
+                    let Token::Legacy(user_sts) = context.tokens().get_user_sts_token()? else {
+                        return Err("User STS token isn't legacy".into());
+                    };
+                    let device_token = context
+                        .device_token
+                        .as_ref()
+                        .ok_or("No device token; the service has no device identity")?;
+
+                    let xsts = if req.app_id.is_empty() {
+                        // No title identity to offer; good enough for
+                        // http://xboxlive.com, which is what sign-in needs.
+                        xodus::api::xbox::run(
+                            &context.client,
+                            device_token.clone(),
+                            user_sts,
+                            &req.relying_party,
+                        )
+                        .await?
+                    } else {
+                        let proof_key = context.tokens().get_or_create_proof_key()?;
+                        let device_id = context.tokens().get_or_create_device_id()?;
+
+                        match xodus::api::xbox::run_with_title(
+                            &context.client,
+                            &proof_key,
+                            device_token.clone(),
+                            user_sts.clone(),
+                            &req.relying_party,
+                            &req.app_id,
+                            &device_id,
+                        )
+                        .await
+                        {
+                            Ok(xsts) => xsts,
+                            Err(err) => {
+                                // MSA will not always issue a silent ticket for
+                                // a title's own app id -- Asphalt Legends'
+                                // 00000000441DF337 comes back with reqstatus
+                                // 0x8004882c and no token at all. A token
+                                // without the title claim still carries the
+                                // user, which is enough for relying parties
+                                // that only need to know who is signed in, so
+                                // offer that rather than nothing.
+                                log::warn!(
+                                    "No title-bound token for app {} ({err}); \
+                                     falling back to a user-only token",
+                                    req.app_id
+                                );
+                                xodus::api::xbox::run(
+                                    &context.client,
+                                    device_token.clone(),
+                                    user_sts,
+                                    &req.relying_party,
+                                )
+                                .await?
+                            }
+                        }
+                    };
+                    context.tokens().cache_xsts(&cache_key, &xsts);
+                    xsts
+                }
+            };
+
+            let payload = XstsTokenResponse {
+                expiry: xsts.not_after.timestamp(),
+                xuid: xsts.xuid().unwrap_or_default().to_string(),
+                gamertag: xsts.gamertag().unwrap_or_default().to_string(),
+                signature: String::new(),
+                token: xodus::api::xbox::get_xsts_auth_header(xsts),
+            };
+            let payload = quick_xml::se::to_string(&payload)?;
+            Ok(payload.as_bytes().to_vec())
         }
         _ => Err("Unimplemented".into()),
     }

--- a/crates/xodus-service/src/connection/xml.rs
+++ b/crates/xodus-service/src/connection/xml.rs
@@ -231,6 +231,15 @@ pub async fn parse_message(
                 }
             };
 
+            // Whether the token carries profile claims decides what the title
+            // shows: without them XUserGetGamertag falls back to a placeholder,
+            // and the player sees a stranger's name on their own save.
+            log::debug!(
+                "XSTS token for {relying_party}: xuid {:?}, gamertag {:?}",
+                xsts.xuid(),
+                xsts.gamertag()
+            );
+
             let payload = XstsTokenResponse {
                 expiry: xsts.not_after.timestamp(),
                 xuid: xsts.xuid().unwrap_or_default().to_string(),

--- a/crates/xodus-service/src/connection/xml.rs
+++ b/crates/xodus-service/src/connection/xml.rs
@@ -139,12 +139,22 @@ pub async fn parse_message(
 
             // XSTS tokens are good for hours; minting one per HTTP request would
             // put a SOAP round trip in front of every call the title makes.
+            // Ask Xbox what this URL's relying party actually is. Falling back
+            // to the caller's guess keeps working for the parties named after
+            // their own host, which is all the table would tell us anyway.
+            let relying_party = match req.url.is_empty() {
+                true => req.relying_party.clone(),
+                false => xodus::api::xbox::title::relying_party_for_url(&context.client, &req.url)
+                    .await
+                    .unwrap_or_else(|| req.relying_party.clone()),
+            };
+
             // The app id is part of the identity of the token, not just of the
             // request: a token minted for one title is not usable by another.
             let cache_key = if req.app_id.is_empty() {
-                req.relying_party.clone()
+                relying_party.clone()
             } else {
-                format!("{}#{}", req.relying_party, req.app_id)
+                format!("{relying_party}#{}", req.app_id)
             };
             let cached = if req.force_refresh {
                 None
@@ -173,7 +183,7 @@ pub async fn parse_message(
                             &context.client,
                             device_token.clone(),
                             user_sts,
-                            &req.relying_party,
+                            &relying_party,
                         )
                         .await?
                     } else {
@@ -185,7 +195,7 @@ pub async fn parse_message(
                             &proof_key,
                             device_token.clone(),
                             user_sts.clone(),
-                            &req.relying_party,
+                            &relying_party,
                             &req.app_id,
                             &device_id,
                         )
@@ -210,7 +220,7 @@ pub async fn parse_message(
                                     &context.client,
                                     device_token.clone(),
                                     user_sts,
-                                    &req.relying_party,
+                                    &relying_party,
                                 )
                                 .await?
                             }

--- a/crates/xodus-service/src/connection/xml.rs
+++ b/crates/xodus-service/src/connection/xml.rs
@@ -1,3 +1,4 @@
+use base64::Engine as _;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use xodus::models::live::ExchangeUserTokenOutcome;
 use xodus::models::secrets::Token;
@@ -301,8 +302,24 @@ pub async fn parse_message(
                 Ok(proof_key) => {
                     let method = if req.method.is_empty() { "GET" } else { &req.method };
                     let path = if req.path_and_query.is_empty() { "/" } else { &req.path_and_query };
-                    let signature = proof_key.sign_request(method, path, &token, b"");
-                    log::debug!("signed {method} {path} for {relying_party}");
+                    // The body counts too. It arrives base64 -- the request
+                    // carrying it is XML -- and anything that fails to decode
+                    // is signed as empty rather than as its own encoding.
+                    let body = if req.body.is_empty() {
+                        Vec::new()
+                    } else {
+                        base64::engine::general_purpose::STANDARD
+                            .decode(&req.body)
+                            .unwrap_or_else(|err| {
+                                log::warn!("undecodable request body, signing without it: {err}");
+                                Vec::new()
+                            })
+                    };
+                    let signature = proof_key.sign_request(method, path, &token, &body);
+                    log::debug!(
+                        "signed {method} {path} ({} body bytes) for {relying_party}",
+                        body.len()
+                    );
                     signature
                 }
                 Err(err) => {

--- a/crates/xodus/Cargo.toml
+++ b/crates/xodus/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = "2.0.19"
 num-bigint-dig = "0.9.1"
 num-integer = "0.1.46"
 kryptering = "0.5.0"
+p256 = { version = "0.14.0", features = ["ecdsa", "pkcs8"] }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 smbios-lib = "0.9.4"

--- a/crates/xodus/proto/xodus/common.proto
+++ b/crates/xodus/proto/xodus/common.proto
@@ -8,4 +8,8 @@ enum XodusMessageType {
     PONG = 2;
     MSA_TOKEN_REQUEST=3;
     MSA_TOKEN_RESPONSE=4;
+    // XUserGetTokenAndSignature: an XSTS token for one relying party. The
+    // router answers with request+1, so requests stay odd.
+    XSTS_TOKEN_REQUEST=5;
+    XSTS_TOKEN_RESPONSE=6;
 }

--- a/crates/xodus/src/api/live/rst/request.rs
+++ b/crates/xodus/src/api/live/rst/request.rs
@@ -27,7 +27,17 @@ impl<'a> RSTRequest<'a> {
         .await?;
 
         let response_text = response.text().await?;
-        let envelope: soap::Envelope = quick_xml::de::from_str(&response_text)?;
+        let envelope: soap::Envelope = match quick_xml::de::from_str(&response_text) {
+            Ok(envelope) => envelope,
+            Err(err) => {
+                // The body is the only thing that says WHY: MSA answers a
+                // refused exchange with a fault whose shape does not match the
+                // token response, and the deserializer error alone names a
+                // missing field rather than the refusal.
+                log::error!("Could not parse the RST response ({err}); body: {response_text}");
+                return Err(err.into());
+            }
+        };
 
         verify_and_decrypt_envelope(self.signature, response_text, envelope)
     }

--- a/crates/xodus/src/api/live/utils.rs
+++ b/crates/xodus/src/api/live/utils.rs
@@ -132,7 +132,26 @@ pub fn decrypt_soap_encrypted_data<T: serde::de::DeserializeOwned>(
             // MSA encrypts refusals too, so the body is the only thing that
             // says why one was refused; the deserializer error alone just names
             // whichever field the fault happens not to have.
-            log::error!("Could not parse the decrypted SOAP body ({err}): {result}");
+            // A refusal comes back as a well-formed response carrying a
+            // Passport fault instead of a token, so deserialisation fails on
+            // the missing token field and the real reason -- a status code
+            // sitting right there in the body -- never gets reported. Say the
+            // code, and keep the body for anything unrecognised.
+            let fault = |tag: &str| {
+                let open = format!("<psf:{tag}>");
+                let close = format!("</psf:{tag}>");
+                result
+                    .split_once(&open)
+                    .and_then(|(_, rest)| rest.split_once(&close))
+                    .map(|(value, _)| value.to_string())
+            };
+            match (fault("reqstatus"), fault("errorstatus")) {
+                (Some(req), status) => log::error!(
+                    "MSA returned a fault instead of a token: reqstatus {req}{}",
+                    status.map(|s| format!(", errorstatus {s}")).unwrap_or_default()
+                ),
+                _ => log::error!("Could not parse the decrypted SOAP body ({err}): {result}"),
+            }
             Err(err.into())
         }
     }

--- a/crates/xodus/src/api/live/utils.rs
+++ b/crates/xodus/src/api/live/utils.rs
@@ -118,11 +118,22 @@ pub fn decrypt_soap_encrypted_data<T: serde::de::DeserializeOwned>(
     let decryptor = Aes256CbcDec::new(&key.into(), iv.into());
     let mut block = [0; 8192];
 
-    decryptor
+    // Use the slice the decryptor returns rather than the whole buffer: the
+    // rest is uninitialised zeroes, and parsing them as part of the document
+    // only works by accident.
+    let plaintext = decryptor
         .decrypt_padded_b2b::<Pkcs7>(encrypted, &mut block)
         .expect("Failed");
-    let result = std::str::from_utf8(&block).unwrap();
-    let data = quick_xml::de::from_str::<T>(result)?;
+    let result = std::str::from_utf8(plaintext).unwrap();
 
-    Ok(data)
+    match quick_xml::de::from_str::<T>(result) {
+        Ok(data) => Ok(data),
+        Err(err) => {
+            // MSA encrypts refusals too, so the body is the only thing that
+            // says why one was refused; the deserializer error alone just names
+            // whichever field the fault happens not to have.
+            log::error!("Could not parse the decrypted SOAP body ({err}): {result}");
+            Err(err.into())
+        }
+    }
 }

--- a/crates/xodus/src/api/xbox/auth.rs
+++ b/crates/xodus/src/api/xbox/auth.rs
@@ -68,7 +68,7 @@ pub async fn request_xsts_token_for_title(
     device_token: String,
     title_token: String,
     relying_party: &str,
-) -> reqwest::Result<XstsResponse> {
+) -> Result<XstsResponse, Box<dyn std::error::Error + Send + Sync>> {
     let body = XstsRequest {
         relying_party: Some(relying_party.to_string()),
         token_type: Some("JWT".to_string()),
@@ -88,10 +88,21 @@ pub async fn request_xsts_token_for_title(
         .header("x-xbl-contract-version", "1")
         .json(&body)
         .send()
-        .await?
-        .error_for_status()?;
+        .await?;
 
-    resp.json().await
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let text = resp.text().await?;
+    if !status.is_success() {
+        // XSTS puts its reason in an XErr code and the body, both of which
+        // error_for_status throws away.
+        return Err(crate::api::xbox::signature::describe_failure(
+            "XSTS authorize", status, &headers, &text,
+        )
+        .into());
+    }
+
+    Ok(serde_json::from_str(&text)?)
 }
 
 pub fn get_xsts_auth_header(xsts: XstsResponse) -> String {

--- a/crates/xodus/src/api/xbox/auth.rs
+++ b/crates/xodus/src/api/xbox/auth.rs
@@ -41,6 +41,44 @@ pub async fn request_xsts_token(
             sandbox_id: Some("RETAIL".to_string()),
             delegation_token: None,
             service_token: None,
+            device_token: None,
+            title_token: None,
+        },
+    };
+
+    let resp = client
+        .post("https://xsts.auth.xboxlive.com/xsts/authorize")
+        .header("Content-Type", "application/json")
+        .header("x-xbl-contract-version", "1")
+        .json(&body)
+        .send()
+        .await?
+        .error_for_status()?;
+
+    resp.json().await
+}
+
+/// The same authorize call, but with the device and title tokens attached.
+///
+/// A token minted without them says who the user is and nothing about which
+/// title is asking, which PlayFab rejects as "The title could not be found".
+pub async fn request_xsts_token_for_title(
+    client: &reqwest::Client,
+    user_token: String,
+    device_token: String,
+    title_token: String,
+    relying_party: &str,
+) -> reqwest::Result<XstsResponse> {
+    let body = XstsRequest {
+        relying_party: Some(relying_party.to_string()),
+        token_type: Some("JWT".to_string()),
+        properties: XstsPropertyBag {
+            user_tokens: Some(vec![user_token]),
+            device_token: Some(device_token),
+            title_token: Some(title_token),
+            sandbox_id: Some("RETAIL".to_string()),
+            delegation_token: None,
+            service_token: None,
         },
     };
 

--- a/crates/xodus/src/api/xbox/device.rs
+++ b/crates/xodus/src/api/xbox/device.rs
@@ -1,0 +1,89 @@
+//! Xbox device authentication.
+//!
+//! Not to be confused with `tokens::device`, which provisions an *MSA* device
+//! credential against login.live.com. This is the Xbox Live side: a token that
+//! says "this device holds the private half of that ProofKey", and it is the
+//! prerequisite for asking sisu or title.auth for a title token.
+
+use serde::Serialize;
+
+use crate::api::xbox::signature::{ProofKey, ProofKeyJwk};
+use crate::models::xbox::AuthTokenResponse;
+
+const DEVICE_AUTH_URL: &str = "https://device.auth.xboxlive.com/device/authenticate";
+
+/// Device authentication with an MSA device RPS ticket.
+///
+/// The ProofOfPossession form below proves only that the caller holds a key it
+/// generated itself, which title.auth will not accept as a title-capable device
+/// (403). This form additionally presents the device's own MSA credential --
+/// the one `tokens::device` provisions against login.live.com -- so the
+/// resulting device token stands for a registered device.
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct DeviceRpsProperties {
+    auth_method: String,
+    site_name: String,
+    rps_ticket: String,
+    id: String,
+    device_type: String,
+    version: String,
+    proof_key: ProofKeyJwk,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct DeviceRpsRequest {
+    relying_party: String,
+    token_type: String,
+    properties: DeviceRpsProperties,
+}
+
+pub async fn authenticate_device_rps(
+    client: &reqwest::Client,
+    proof_key: &ProofKey,
+    device_id: &str,
+    device_type: &str,
+    device_rps: &str,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    let body = DeviceRpsRequest {
+        relying_party: "http://auth.xboxlive.com".to_string(),
+        token_type: "JWT".to_string(),
+        properties: DeviceRpsProperties {
+            auth_method: "RPS".to_string(),
+            site_name: "user.auth.xboxlive.com".to_string(),
+            rps_ticket: device_rps.to_string(),
+            id: format!("{{{device_id}}}"),
+            device_type: device_type.to_string(),
+            version: "10.0.22631".to_string(),
+            proof_key: proof_key.jwk(),
+        },
+    };
+
+    let body = serde_json::to_vec(&body)?;
+    let signature = proof_key.sign_request("POST", "/device/authenticate", "", &body);
+
+    let resp = client
+        .post(DEVICE_AUTH_URL)
+        .header("Content-Type", "application/json")
+        .header("x-xbl-contract-version", "1")
+        .header("Signature", signature)
+        .body(body)
+        .send()
+        .await?;
+
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let text = resp.text().await?;
+    if !status.is_success() {
+        return Err(crate::api::xbox::signature::describe_failure(
+            "device RPS authentication",
+            status,
+            &headers,
+            &text,
+        )
+        .into());
+    }
+
+    Ok(serde_json::from_str::<AuthTokenResponse>(&text)?.token)
+}

--- a/crates/xodus/src/api/xbox/mod.rs
+++ b/crates/xodus/src/api/xbox/mod.rs
@@ -112,31 +112,52 @@ async fn rps_ticket_for_app(
     legacy: LegacyToken,
     app_id: &str,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-    // The token-broker path, with the app id in the scope. This is what the
-    // Windows GDK asks WGC for on the title's behalf, and unlike a plain
-    // user.auth ticket the result is actually bound to the app -- title.auth
-    // answers 403 for a ticket that names no title.
-    let outcome = crate::api::live::exchange_user_token(
-        client,
-        legacy,
-        "USERNAME".to_string(),
-        dev_token,
-        None,
-        Some("Silent".to_string()),
-        app_id.to_string(),
-        &[
-            (
-                format!(
-                    "scope=service::user.auth.xboxlive.com::MBI_SSL&api-version=2.0&clientid={app_id}"
-                ),
-                Some(soap::PolicyReference::token_broker()),
-            ),
-            ("http://Passport.NET/tb".to_string(), None),
-        ],
-    )
-    .await?;
+    // The token-broker form, with the app id in the scope. title.auth only
+    // accepts this one: a plain user.auth ticket for the same hosting app is
+    // issued happily by MSA and then rejected with 400.
+    //
+    // MSA will not always issue it, though: Asphalt Legends' 00000000441DF337
+    // comes back with reqstatus 0x8004882c / errorstatus 0x80045c30 and no
+    // token at all, while Minecraft's is fine. Asking without the "Silent"
+    // constraint returns the identical pair, so it is the app-and-scope
+    // combination being refused rather than the interaction mode -- which also
+    // means no amount of consent UI would change it. Try the narrower
+    // xboxlive.signin scope before giving up on a title claim.
+    let attempts = [
+        format!("scope=service::user.auth.xboxlive.com::MBI_SSL&api-version=2.0&clientid={app_id}"),
+        format!("scope=xboxlive.signin&api-version=2.0&clientid={app_id}"),
+    ];
 
-    compact_token(outcome)
+    let mut last_err = None;
+    for scope in attempts {
+        let policies = [
+            (scope.clone(), Some(soap::PolicyReference::token_broker())),
+            ("http://Passport.NET/tb".to_string(), None),
+        ];
+
+        match crate::api::live::exchange_user_token(
+            client,
+            legacy.clone(),
+            "USERNAME".to_string(),
+            dev_token.clone(),
+            None,
+            Some("Silent".to_string()),
+            app_id.to_string(),
+            &policies,
+        )
+        .await
+        {
+            Ok(outcome) => return compact_token(outcome),
+            Err(err) => {
+                log::warn!("MSA refused {scope}: {err}");
+                last_err = Some(err);
+            }
+        }
+    }
+
+    Err(last_err
+        .map(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)
+        .unwrap_or_else(|| "no scope was attempted".into()))
 }
 
 /// The full chain, including the title claim.
@@ -177,6 +198,7 @@ pub async fn run_with_title(
 
     // One ticket, two tokens: user.auth says who is signed in, title.auth says
     // which title they are signed in through.
+    log::debug!("RPS ticket starts {:?}", &rps_ticket[..rps_ticket.len().min(8)]);
     let title_token = title::authenticate_title(client, proof_key, &rps_ticket, &device_token).await?;
     let user_token = authenticate_xbox_user(client, rps_ticket).await?.token;
 

--- a/crates/xodus/src/api/xbox/mod.rs
+++ b/crates/xodus/src/api/xbox/mod.rs
@@ -4,15 +4,25 @@ use crate::models::soap;
 use crate::models::xbox::XstsResponse;
 
 pub mod auth;
+pub mod device;
+pub mod signature;
 pub mod title;
 pub use auth::{authenticate_xbox_user, get_xsts_auth_header, request_xsts_token};
+pub use signature::ProofKey;
 
+/// MSA user token -> Xbox user token -> XSTS token for `relying_party`.
+///
+/// The relying party is whatever the caller needs a token for:
+/// `http://xboxlive.com` for Xbox Live services,
+/// `https://b980a380.minecraft.playfabapi.com/` for Minecraft Bedrock's PlayFab
+/// title, and so on. No device or title token is attached; the parties reached
+/// this way accept a plain user token.
 pub async fn run(
     client: &reqwest::Client,
     dev_token: LegacyToken,
     legacy: LegacyToken,
     relying_party: &str,
-) -> XstsResponse {
+) -> Result<XstsResponse, Box<dyn std::error::Error + Send + Sync>> {
     let user_token = crate::api::live::exchange_user_token(
         client,
         legacy,
@@ -26,34 +36,156 @@ pub async fn run(
             Some(soap::PolicyReference::mbi_ssl()),
         )],
     )
-    .await
-    .expect("Failed to get ms user token");
+    .await?;
 
     let user_token: Token = match user_token {
-        ExchangeUserTokenOutcome::Fault(_) => {
-            eprintln!("Failed to get exchange MS token");
-            panic!("TODO");
+        ExchangeUserTokenOutcome::Fault(fault) => {
+            return Err(format!("MSA rejected the user token exchange: {fault:?}").into());
         }
         ExchangeUserTokenOutcome::Issued(
             soap::BodyContent::RequestSecurityTokenResponseCollection(mut collection),
         ) => {
-            let token = collection.security_tokens.remove(0);
-            token.into()
+            if collection.security_tokens.is_empty() {
+                return Err("MSA returned no security tokens".into());
+            }
+            collection.security_tokens.remove(0).into()
         }
         ExchangeUserTokenOutcome::Issued(soap::BodyContent::RequestSecurityTokenResponse(
             token,
         )) => (*token).into(),
-        _ => unreachable!("Only responses are handled"),
+        _ => return Err("Unexpected SOAP body in the user token exchange".into()),
     };
     let Token::Compact(user_token) = user_token else {
-        eprintln!("Unsupported token");
-        panic!("TODO");
+        return Err("MSA returned a legacy token where a compact one was expected".into());
     };
-    let resp = authenticate_xbox_user(client, user_token)
-        .await
-        .expect("Failed to authenticate Xbox user");
 
-    request_xsts_token(client, resp.token, relying_party)
-        .await
-        .expect("Failed to authenticate Xbox user")
+    let resp = authenticate_xbox_user(client, user_token).await?;
+
+    Ok(request_xsts_token(client, resp.token, relying_party).await?)
+}
+
+/// Pull the compact token out of whatever shape MSA answered with.
+fn compact_token(outcome: ExchangeUserTokenOutcome) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    let token: Token = match outcome {
+        ExchangeUserTokenOutcome::Fault(fault) => {
+            return Err(format!("MSA rejected the token exchange: {fault:?}").into());
+        }
+        ExchangeUserTokenOutcome::Issued(
+            soap::BodyContent::RequestSecurityTokenResponseCollection(mut collection),
+        ) => {
+            if collection.security_tokens.is_empty() {
+                return Err("MSA returned no security tokens".into());
+            }
+            for token in &collection.security_tokens {
+                log::debug!(
+                    "MSA issued a token for {}",
+                    token.applies_to.endpoint_reference.address
+                );
+            }
+            collection.security_tokens.remove(0).into()
+        }
+        ExchangeUserTokenOutcome::Issued(soap::BodyContent::RequestSecurityTokenResponse(token)) => {
+            log::debug!(
+                "MSA issued a token for {}",
+                token.applies_to.endpoint_reference.address
+            );
+            (*token).into()
+        }
+        _ => return Err("Unexpected SOAP body in the token exchange".into()),
+    };
+
+    match token {
+        Token::Compact(token) => Ok(token),
+        Token::Legacy(_) => Err("MSA returned a legacy token where a compact one was expected".into()),
+    }
+}
+
+/// An RPS ticket for `user.auth.xboxlive.com`, issued to one title's own MSA
+/// app id rather than to a generic client.
+///
+/// Same shape and policy as the ticket `run()` already uses successfully -- only
+/// the hosting app differs, and that is what carries the title's identity into
+/// the token chain.
+async fn rps_ticket_for_app(
+    client: &reqwest::Client,
+    dev_token: LegacyToken,
+    legacy: LegacyToken,
+    app_id: &str,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    // The token-broker path, with the app id in the scope. This is what the
+    // Windows GDK asks WGC for on the title's behalf, and unlike a plain
+    // user.auth ticket the result is actually bound to the app -- title.auth
+    // answers 403 for a ticket that names no title.
+    let outcome = crate::api::live::exchange_user_token(
+        client,
+        legacy,
+        "USERNAME".to_string(),
+        dev_token,
+        None,
+        Some("Silent".to_string()),
+        app_id.to_string(),
+        &[
+            (
+                format!(
+                    "scope=service::user.auth.xboxlive.com::MBI_SSL&api-version=2.0&clientid={app_id}"
+                ),
+                Some(soap::PolicyReference::token_broker()),
+            ),
+            ("http://Passport.NET/tb".to_string(), None),
+        ],
+    )
+    .await?;
+
+    compact_token(outcome)
+}
+
+/// The full chain, including the title claim.
+///
+/// `app_id` is the title's `<MSAAppId>` from MicrosoftGame.Config (Minecraft
+/// Bedrock: 0000000040159362). Without it the resulting token has only a `xui`
+/// claim and services that key off the title -- PlayFab, the in-game
+/// marketplace -- refuse it.
+pub async fn run_with_title(
+    client: &reqwest::Client,
+    proof_key: &ProofKey,
+    dev_token: LegacyToken,
+    legacy: LegacyToken,
+    relying_party: &str,
+    app_id: &str,
+    device_id: &str,
+) -> Result<XstsResponse, Box<dyn std::error::Error + Send + Sync>> {
+    let rps_ticket = rps_ticket_for_app(client, dev_token.clone(), legacy, app_id).await?;
+
+    // The device's own MSA credential, exchanged for a ticket user.auth accepts.
+    // This is what makes the device token count as a registered device: a
+    // ProofOfPossession token, which proves only that we hold a key we made up
+    // ourselves, gets a 403 out of title.auth.
+    let device_rps = crate::api::live::exchange_device_token(
+        client,
+        dev_token,
+        "{28C08266-F973-4AE6-FFE4-409B249F138F}".to_string(),
+        "scope=service::user.auth.xboxlive.com::MBI_SSL".to_owned(),
+        Some(soap::PolicyReference::token_broker()),
+    )
+    .await?;
+    let Token::Compact(device_rps) = Token::from(device_rps) else {
+        return Err("MSA returned a legacy device token".into());
+    };
+
+    let device_token =
+        device::authenticate_device_rps(client, proof_key, device_id, "Win32", &device_rps).await?;
+
+    // One ticket, two tokens: user.auth says who is signed in, title.auth says
+    // which title they are signed in through.
+    let title_token = title::authenticate_title(client, proof_key, &rps_ticket, &device_token).await?;
+    let user_token = authenticate_xbox_user(client, rps_ticket).await?.token;
+
+    Ok(auth::request_xsts_token_for_title(
+        client,
+        user_token,
+        device_token,
+        title_token,
+        relying_party,
+    )
+    .await?)
 }

--- a/crates/xodus/src/api/xbox/signature.rs
+++ b/crates/xodus/src/api/xbox/signature.rs
@@ -1,0 +1,175 @@
+//! Xbox Live request signing.
+//!
+//! `device.auth`, `title.auth` and `sisu` will not talk to a caller that cannot
+//! prove it holds a private key: each request carries a `Signature` header, and
+//! the matching public key is handed over in the body as a JWK ("ProofKey").
+//! The signature covers the request itself, so it cannot be replayed against a
+//! different method, path or body.
+//!
+//! The layout below is the version-1 signature policy, which is what
+//! `title.mgt.xboxlive.com/titles/default/endpoints` advertises for these hosts
+//! (`SupportedAlgorithms: ["ES256"]`).
+
+use base64::Engine;
+use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
+use p256::ecdsa::signature::Signer;
+use p256::ecdsa::{Signature, SigningKey};
+use serde::{Deserialize, Serialize};
+
+/// Seconds between the Windows FILETIME epoch (1601-01-01) and the Unix epoch.
+const FILETIME_EPOCH_DELTA: i64 = 11_644_473_600;
+
+const SIGNATURE_VERSION: u32 = 1;
+
+/// The public half, as Xbox Live wants to see it in a request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProofKeyJwk {
+    pub crv: String,
+    pub alg: String,
+    #[serde(rename = "use")]
+    pub key_use: String,
+    pub kty: String,
+    pub x: String,
+    pub y: String,
+}
+
+/// A device's ECDSA P-256 key pair.
+///
+/// This is the device identity: once a device token has been issued against it,
+/// the same key has to sign every later request, so it is persisted in the
+/// keyring rather than regenerated per run.
+#[derive(Clone)]
+pub struct ProofKey {
+    signing_key: SigningKey,
+}
+
+impl ProofKey {
+    pub fn generate() -> Self {
+        Self {
+            signing_key: SigningKey::random(&mut rand::rng()),
+        }
+    }
+
+    /// The private scalar, 32 bytes big-endian.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.signing_key.to_bytes().to_vec()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        SigningKey::from_slice(bytes)
+            .ok()
+            .map(|signing_key| Self { signing_key })
+    }
+
+    pub fn jwk(&self) -> ProofKeyJwk {
+        let point = self.signing_key.verifying_key().to_sec1_point(false);
+
+        ProofKeyJwk {
+            crv: "P-256".to_string(),
+            alg: "ES256".to_string(),
+            key_use: "sig".to_string(),
+            kty: "EC".to_string(),
+            // Uncompressed SEC1 is 0x04 || X || Y; the JWK wants the halves
+            // separately, base64url with no padding.
+            x: URL_SAFE_NO_PAD.encode(point.x().expect("P-256 point has an x")),
+            y: URL_SAFE_NO_PAD.encode(point.y().expect("uncompressed point has a y")),
+        }
+    }
+
+    /// Build the `Signature` header for one request.
+    ///
+    /// `path_and_query` is the URL from the path onwards ("/device/authenticate"),
+    /// `authorization` is the Authorization header being sent or "" if none, and
+    /// `body` is the exact bytes that will go on the wire.
+    pub fn sign_request(
+        &self,
+        method: &str,
+        path_and_query: &str,
+        authorization: &str,
+        body: &[u8],
+    ) -> String {
+        let filetime =
+            ((chrono::Utc::now().timestamp() + FILETIME_EPOCH_DELTA) as u64) * 10_000_000;
+        let version = SIGNATURE_VERSION.to_be_bytes();
+        let timestamp = filetime.to_be_bytes();
+
+        // Every field is NUL-terminated, including the last one.
+        let mut payload = Vec::with_capacity(body.len() + 128);
+        payload.extend_from_slice(&version);
+        payload.push(0);
+        payload.extend_from_slice(&timestamp);
+        payload.push(0);
+        payload.extend_from_slice(method.as_bytes());
+        payload.push(0);
+        payload.extend_from_slice(path_and_query.as_bytes());
+        payload.push(0);
+        payload.extend_from_slice(authorization.as_bytes());
+        payload.push(0);
+        payload.extend_from_slice(body);
+        payload.push(0);
+
+        let signature: Signature = self.signing_key.sign(&payload);
+
+        // The header repeats the version and timestamp in the clear so the
+        // server can rebuild the same payload before verifying.
+        let mut header = Vec::with_capacity(4 + 8 + 64);
+        header.extend_from_slice(&version);
+        header.extend_from_slice(&timestamp);
+        header.extend_from_slice(&signature.to_bytes());
+
+        STANDARD.encode(header)
+    }
+}
+
+
+/// Xbox Live reports auth failures in headers, not the body: a bare 401 with an
+/// empty body still carries `WWW-Authenticate` and an `X-Err` code.
+pub(crate) fn describe_failure(what: &str, status: reqwest::StatusCode, headers: &reqwest::header::HeaderMap, body: &str) -> String {
+    let header = |name: &str| {
+        headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string()
+    };
+
+    format!(
+        "{what} failed ({status}); x-err {:?}, www-authenticate {:?}, body {:?}",
+        header("x-err"),
+        header("www-authenticate"),
+        body
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn proof_key_round_trips_through_bytes() {
+        let key = ProofKey::generate();
+        let restored = ProofKey::from_bytes(&key.to_bytes()).expect("valid scalar");
+
+        assert_eq!(key.jwk().x, restored.jwk().x);
+        assert_eq!(key.jwk().y, restored.jwk().y);
+    }
+
+    #[test]
+    fn jwk_halves_are_32_bytes_each() {
+        let jwk = ProofKey::generate().jwk();
+
+        assert_eq!(URL_SAFE_NO_PAD.decode(&jwk.x).unwrap().len(), 32);
+        assert_eq!(URL_SAFE_NO_PAD.decode(&jwk.y).unwrap().len(), 32);
+        assert_eq!(jwk.crv, "P-256");
+    }
+
+    #[test]
+    fn signature_header_is_version_timestamp_and_raw_signature() {
+        let key = ProofKey::generate();
+        let header = key.sign_request("POST", "/device/authenticate", "", b"{}");
+        let raw = STANDARD.decode(header).expect("base64");
+
+        assert_eq!(raw.len(), 4 + 8 + 64);
+        assert_eq!(u32::from_be_bytes(raw[0..4].try_into().unwrap()), 1);
+    }
+}

--- a/crates/xodus/src/api/xbox/title.rs
+++ b/crates/xodus/src/api/xbox/title.rs
@@ -101,6 +101,47 @@ pub fn get_endpoint<'a>(url: &str, response: &'a TitleMgtResponse) -> Option<&'a
         .copied()
 }
 
+
+use tokio::sync::OnceCell;
+
+/// The endpoint table, fetched once per process.
+///
+/// It is the same document for every caller and changes about as often as Xbox
+/// Live itself, so re-fetching it per token request would be pure latency.
+static ENDPOINTS: OnceCell<TitleMgtResponse> = OnceCell::const_new();
+
+/// The relying party Xbox Live expects for a given request URL.
+///
+/// A token is issued to a relying party, not to a URL, and the mapping is not
+/// something a caller can derive: `*.xboxlive.com` all map to
+/// `http://xboxlive.com`, `playfabapi.com` maps to `http://playfab.xboxlive.com/`,
+/// and so on. Deriving `scheme://host/` from the URL instead happens to work for
+/// the handful of parties that are named after their own host, and fails with a
+/// bare 400 from XSTS for everything else -- which is what
+/// `wss://rta.xboxlive.com/` does.
+pub async fn relying_party_for_url(client: &reqwest::Client, url: &str) -> Option<String> {
+    let table = ENDPOINTS
+        .get_or_try_init(|| get_title_management(client))
+        .await
+        .ok()?;
+
+    // The table only describes http/https. A WebSocket URL is the same
+    // endpoint reached over the same transport, so match it as its http twin.
+    let normalized = match url.split_once("://") {
+        Some(("wss", rest)) => format!("https://{rest}"),
+        Some(("ws", rest)) => format!("http://{rest}"),
+        _ => url.to_string(),
+    };
+
+    let endpoint = get_endpoint(&normalized, table)?;
+    let relying_party = endpoint.relying_party.clone();
+    log::debug!(
+        "{url} -> relying party {}",
+        relying_party.as_deref().unwrap_or("(none listed)")
+    );
+    relying_party
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/xodus/src/api/xbox/title.rs
+++ b/crates/xodus/src/api/xbox/title.rs
@@ -1,3 +1,75 @@
+use serde::Serialize;
+
+use crate::api::xbox::signature::{ProofKey, ProofKeyJwk};
+use crate::models::xbox::AuthTokenResponse;
+
+const TITLE_AUTH_URL: &str = "https://title.auth.xboxlive.com/title/authenticate";
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct TitleAuthProperties {
+    auth_method: String,
+    device_token: String,
+    site_name: String,
+    rps_ticket: String,
+    proof_key: ProofKeyJwk,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct TitleAuthRequest {
+    relying_party: String,
+    token_type: String,
+    properties: TitleAuthProperties,
+}
+
+/// A token saying which title the user is signed in through.
+///
+/// `rps_ticket` must be an RPS ticket issued to the *title's* MSA app id -- that
+/// is where the title identity comes from -- and `device_token` must have been
+/// minted with the same ProofKey that signs this request.
+pub async fn authenticate_title(
+    client: &reqwest::Client,
+    proof_key: &ProofKey,
+    rps_ticket: &str,
+    device_token: &str,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    let body = TitleAuthRequest {
+        relying_party: "http://auth.xboxlive.com".to_string(),
+        token_type: "JWT".to_string(),
+        properties: TitleAuthProperties {
+            auth_method: "RPS".to_string(),
+            device_token: device_token.to_string(),
+            site_name: "user.auth.xboxlive.com".to_string(),
+            rps_ticket: rps_ticket.to_string(),
+            proof_key: proof_key.jwk(),
+        },
+    };
+
+    let body = serde_json::to_vec(&body)?;
+    let signature = proof_key.sign_request("POST", "/title/authenticate", "", &body);
+
+    let resp = client
+        .post(TITLE_AUTH_URL)
+        .header("Content-Type", "application/json")
+        .header("x-xbl-contract-version", "1")
+        .header("Signature", signature)
+        .body(body)
+        .send()
+        .await?;
+
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let text = resp.text().await?;
+    if !status.is_success() {
+        return Err(
+            crate::api::xbox::signature::describe_failure("title authentication", status, &headers, &text).into(),
+        );
+    }
+
+    Ok(serde_json::from_str::<AuthTokenResponse>(&text)?.token)
+}
+
 use crate::models::xbox::{TitleMgtEndPoint, TitleMgtResponse};
 
 pub async fn get_title_management(client: &reqwest::Client) -> reqwest::Result<TitleMgtResponse> {

--- a/crates/xodus/src/models/xbox.rs
+++ b/crates/xodus/src/models/xbox.rs
@@ -18,6 +18,18 @@ pub struct UserAuthProperties {
     pub rps_ticket: String,
 }
 
+/// Device and title tokens.
+///
+/// They come back in the same envelope as an XSTS token but with a different
+/// claim shape -- a title token's `DisplayClaims.xti` is an object, not the
+/// array `XstsResponse` expects -- and nothing here needs the claims anyway.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct AuthTokenResponse {
+    pub not_after: chrono::DateTime<chrono::Utc>,
+    pub token: String,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct XstsResponse {
@@ -55,6 +67,20 @@ impl XstsResponse {
             .first()
             .map(|claim| claim.uhs.as_str())
     }
+
+    pub fn xuid(&self) -> Option<&str> {
+        self.display_claims
+            .xui
+            .first()
+            .and_then(|claim| claim.xid.as_deref())
+    }
+
+    pub fn gamertag(&self) -> Option<&str> {
+        self.display_claims
+            .xui
+            .first()
+            .and_then(|claim| claim.gtg.as_deref())
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -71,6 +97,13 @@ pub struct XstsPropertyBag {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delegation_token: Option<String>,
+
+    /// Attaching these two is what puts the `xti` title claim on the result.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_token: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title_token: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/xodus/src/models/xgameruntime/xuser.rs
+++ b/crates/xodus/src/models/xgameruntime/xuser.rs
@@ -18,3 +18,38 @@ pub struct MSATokenResponse {
     pub device_rps: String,
     pub device_expiry: i64,
 }
+
+/// XUserGetTokenAndSignature, relayed from the Wine side. The relying party is
+/// derived from the request URL: Minecraft asks for
+/// `https://b980a380.minecraft.playfabapi.com/`, the well-known Bedrock PlayFab
+/// party.
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct XstsTokenRequest {
+    pub relying_party: String,
+    /// XUserGetTokenAndSignatureOptions::ForceRefresh - bypass the cache.
+    #[serde(default)]
+    pub force_refresh: bool,
+    /// The title's `<MSAAppId>` from MicrosoftGame.Config. When present the
+    /// token is minted through sisu so it carries the title claim; without it
+    /// the user-token-only chain is used and PlayFab-style services refuse the
+    /// result.
+    #[serde(default)]
+    pub app_id: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct XstsTokenResponse {
+    /// Ready to use as an Authorization header: `XBL3.0 x=<uhs>;<jwt>`.
+    pub token: String,
+    pub expiry: i64,
+    /// Empty. Only xboxlive.com endpoints check a proof-of-possession
+    /// signature, and reaching those needs a device key we do not have yet.
+    #[serde(default)]
+    pub signature: String,
+    /// Real identity from the XSTS xui claim, so XUserGetId/XUserGetGamertag
+    /// can agree with the token the title is about to send.
+    pub xuid: String,
+    pub gamertag: String,
+}

--- a/crates/xodus/src/models/xgameruntime/xuser.rs
+++ b/crates/xodus/src/models/xgameruntime/xuser.rs
@@ -41,6 +41,13 @@ pub struct XstsTokenRequest {
     /// result.
     #[serde(default)]
     pub app_id: String,
+    /// The HTTP method of the request the title is about to send. Part of what
+    /// the signature covers, so it cannot be replayed against another verb.
+    #[serde(default)]
+    pub method: String,
+    /// The request path with its query, likewise covered by the signature.
+    #[serde(default)]
+    pub path_and_query: String,
 }
 
 #[derive(Serialize)]
@@ -49,8 +56,11 @@ pub struct XstsTokenResponse {
     /// Ready to use as an Authorization header: `XBL3.0 x=<uhs>;<jwt>`.
     pub token: String,
     pub expiry: i64,
-    /// Empty. Only xboxlive.com endpoints check a proof-of-possession
-    /// signature, and reaching those needs a device key we do not have yet.
+    /// Proof of possession over this exact request.
+    ///
+    /// Xbox's endpoint table gives `*.xboxlive.com` a signature policy, and
+    /// real-time activity enforces it: without a signature the websocket
+    /// connect is answered with 401 and the title retries forever.
     #[serde(default)]
     pub signature: String,
     /// Real identity from the XSTS xui claim, so XUserGetId/XUserGetGamertag

--- a/crates/xodus/src/models/xgameruntime/xuser.rs
+++ b/crates/xodus/src/models/xgameruntime/xuser.rs
@@ -48,6 +48,11 @@ pub struct XstsTokenRequest {
     /// The request path with its query, likewise covered by the signature.
     #[serde(default)]
     pub path_and_query: String,
+    /// The body the title is about to send, base64 because the request carrying
+    /// it is XML. Covered by the signature as well: a presence POST signed over
+    /// an empty body does not verify.
+    #[serde(default)]
+    pub body: String,
 }
 
 #[derive(Serialize)]

--- a/crates/xodus/src/models/xgameruntime/xuser.rs
+++ b/crates/xodus/src/models/xgameruntime/xuser.rs
@@ -30,6 +30,11 @@ pub struct XstsTokenRequest {
     /// XUserGetTokenAndSignatureOptions::ForceRefresh - bypass the cache.
     #[serde(default)]
     pub force_refresh: bool,
+    /// The request URL the title asked about. The relying party is resolved
+    /// from it against Xbox's endpoint table; `relying_party` above is only the
+    /// caller's guess, used when the table has nothing to say.
+    #[serde(default)]
+    pub url: String,
     /// The title's `<MSAAppId>` from MicrosoftGame.Config. When present the
     /// token is minted through sisu so it carries the title claim; without it
     /// the user-token-only chain is used and PlayFab-style services refuse the

--- a/crates/xodus/src/tokens/manager.rs
+++ b/crates/xodus/src/tokens/manager.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
+use crate::api::xbox::ProofKey;
 use crate::models::secrets::{Device, Token, TokenStore, User};
 use crate::models::xbox::XstsResponse;
 use crate::tokens::backend::{KeychainBackend, MemoryBackend};
@@ -12,6 +13,8 @@ mod keys {
     pub const DEVICE_TOKENS: &str = "device-tokens";
     pub const USER_TOKENS: &str = "user-tokens";
     pub const USER_INFO: &str = "user-DA";
+    pub const PROOF_KEY: &str = "xbox-proof-key";
+    pub const DEVICE_ID: &str = "xbox-device-id";
 }
 
 pub const PASSPORT_STS: &str = "http://Passport.NET/STS";
@@ -123,6 +126,39 @@ impl TokenManager {
     pub fn save_user(&self, user: &User) -> Result<(), TokenStoreError> {
         self.persistent
             .set(keys::USER_INFO, &serde_json::to_vec(user)?)
+    }
+
+    // ---- Xbox device identity (ProofKey + device id) --------------------------
+
+    /// The device's ECDSA key, generated once and kept.
+    ///
+    /// Xbox Live ties the device token to this key, so regenerating it per run
+    /// would look like a new device every time and lose whatever trust the old
+    /// one had accumulated.
+    pub fn get_or_create_proof_key(&self) -> Result<ProofKey, TokenStoreError> {
+        if let Some(bytes) = self.persistent.get(keys::PROOF_KEY)?
+            && let Some(key) = ProofKey::from_bytes(&bytes)
+        {
+            return Ok(key);
+        }
+
+        let key = ProofKey::generate();
+        self.persistent.set(keys::PROOF_KEY, &key.to_bytes())?;
+        Ok(key)
+    }
+
+    /// The GUID that goes with the ProofKey. Same reasoning: stable per install.
+    pub fn get_or_create_device_id(&self) -> Result<String, TokenStoreError> {
+        if let Some(bytes) = self.persistent.get(keys::DEVICE_ID)?
+            && let Ok(id) = String::from_utf8(bytes)
+            && !id.is_empty()
+        {
+            return Ok(id);
+        }
+
+        let id = uuid::Uuid::new_v4().to_string();
+        self.persistent.set(keys::DEVICE_ID, id.as_bytes())?;
+        Ok(id)
     }
 
     // ---- Ephemeral XSTS-by-relying-party cache --------------------------------


### PR DESCRIPTION
The CLI and service side of running Game Pass titles end to end. Companion to
xodus-gaming/xgameruntime#10 and xodus-gaming/wine#3.

### Downloads resume, and installs stop costing twice the disk

- **An interrupted download continues from its cache** rather than starting
  over (#32). These packages run to tens of gigabytes, and losing all of it to
  a closed lid or an unplugged drive is the difference between an inconvenience
  and an unusable installer.
- **The installed package hands its payload back.** An install was ~2x the
  download because the whole MSIXVC was kept beside the extracted game, though
  only ~0.2% of it is ever read again. Punching out the payload past the prefix
  a launch needs took a library here from 135 GB to 69 GB, with every title
  still launching.
- Exit codes mean something. Five failure paths printed a message and returned
  normally while `run()` returned success unconditionally, so a licence refusal
  exited 0 and an install that produced nothing looked like it had worked.

### The Xbox Live token chain

- The relying party is resolved from Xbox's endpoint table rather than guessed
  from the URL, and the request a title is about to send is signed — including
  its body, which a presence POST needs and which nothing had sent before.
- MSA faults report their actual fault code instead of surfacing as a
  deserialisation failure, and a title ticket MSA has already refused is not
  asked for again on a loop.
- **This overlaps #108**, which mints title-claimed XSTS tokens over IPC and
  touches the same two files. Ours grew from the title side, against real
  titles' `XUserGetTokenAndSignature` calls; if #108 lands first, the signing
  work here rebases onto it cleanly and I am glad to do that.

### Launching

- **The executable is chosen deterministically** (#106). Hades II ships
  `F10.exe` beside `Hades2.exe` and the launcher started the wrong one, so the
  package manifest's `<Application Executable=...>` decides, with a ranking
  fallback for packages that do not declare one. **This overlaps #124**, which
  reads `MicrosoftGame.config` for the same purpose and adds `quick-xml` and
  `serde` to do it; this version needs no new dependencies but theirs reads the
  GDK's own manifest, and I have no attachment to mine winning.
- Arguments after `--` reach the title.

### Verified

Fifteen catalogue titles install and launch, with sign-in, achievements
read and write, real-time activity and presence working against a real Xbox
account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
