### PR TITLE
chore: fix lint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Install protobuf
         if: ${{ runner.os == 'macOS' }}
         run: brew install protobuf
+      - name: Update Rust toolchain
+        run: rustup update
       - uses: actions/cache@v5
         with:
           path: |

--- a/crates/xodus-cli/src/commands/streaming.rs
+++ b/crates/xodus-cli/src/commands/streaming.rs
@@ -341,8 +341,7 @@ where
             }
         })
         .map(|(_, v)| v.length)
-        .reduce(|old, c| old + c)
-        .map_or(0, |x| x);
+        .sum();
 
     let required_free_space = total_size;
     let available_free_space = match available_space(out) {

--- a/crates/xodus/src/licensing/splicense.rs
+++ b/crates/xodus/src/licensing/splicense.rs
@@ -545,6 +545,6 @@ mod tests {
 
         let license =
             SPLicense::decode(Cursor::new(data)).expect("Valid UTF-16 package name should decode");
-        assert_eq!(license.package_name, "Microsoft.Minecraft_8wekyb3d8bbwe");
+        assert_eq!(license.package_name, test_name);
     }
 }

--- a/crates/xodus/src/licensing/splicense.rs
+++ b/crates/xodus/src/licensing/splicense.rs
@@ -204,9 +204,6 @@ pub enum SPLicenseDecodeError {
     #[error("PackedContentKey id_len {id_len} is less than 16")]
     InvalidPackedContentKeyIdLength { id_len: usize },
 
-    #[error("invalid UTF-16 package name byte length {len}")]
-    InvalidPackageNameByteLength { len: usize },
-
     #[error("invalid UTF-16 package name: {0}")]
     InvalidPackageNameUtf16(#[from] std::string::FromUtf16Error),
 }
@@ -262,20 +259,7 @@ impl SPLicense {
             }
             Ok(BlockId::PackageFullName) => {
                 let data = read_vec(&mut reader, size)?;
-                if data.len() % 2 != 0 {
-                    return Err(SPLicenseDecodeError::InvalidPackageNameByteLength {
-                        len: data.len(),
-                    });
-                }
-                let utf16: Vec<u16> = data
-                    .chunks_exact(2)
-                    .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
-                    .collect();
-                let mut s = String::from_utf16(&utf16)?;
-                if s.ends_with('\0') {
-                    s.pop();
-                }
-                self.package_name = s;
+                self.package_name = String::from_utf16le(&data)?;
             }
             Ok(BlockId::PackedContentKeys) => {
                 let mut offset = 0;
@@ -542,7 +526,7 @@ mod tests {
         let result = SPLicense::decode(Cursor::new(data));
         assert!(matches!(
             result,
-            Err(SPLicenseDecodeError::InvalidPackageNameByteLength { len: 3 })
+            Err(SPLicenseDecodeError::InvalidPackageNameUtf16(_))
         ));
     }
 


### PR DESCRIPTION
Now that the required Rust version has been bumped, use the new `String::from_utf16le` function. Also, simplify another thing that was triggering clippy.