### PR TITLE
fix: set WEBKIT_DISABLE_DMABUF_RENDERER before tokio runtime starts

### DIFF
--- a/crates/xodus-cli/src/main.rs
+++ b/crates/xodus-cli/src/main.rs
@@ -110,8 +110,26 @@ struct CliArgs {
     command: SubCommand,
 }
 
-#[tokio::main]
-async fn main() -> ExitCode {
+fn main() -> ExitCode {
+    #[cfg(target_os = "linux")]
+    {
+        // WebKitGTK's DMA-BUF renderer (default since 2.42) fails silently on many
+        // wlroots-based compositors (Hyprland, Sway), surfacing as repeated
+        // "Failed to create GBM buffer" messages while the login webview never
+        // renders. Setting this before startup avoids it.
+        if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+            // SAFETY: main() is still single-threaded here, before the tokio
+            // runtime exists so there's no concurrent reader of the enviroment
+            unsafe {std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1")} ;
+        }
+    }
+
+    tokio::runtime::Runtime::new()
+        .expect("failed to build tokio runtime")
+        .block_on(run())
+}
+
+async fn run() -> ExitCode {
     env_logger::init_from_env("XODUS_LOG");
     let client = reqwest::ClientBuilder::new()
         .user_agent(format!("xodus-cli/{}", env!("CARGO_PKG_VERSION")))

--- a/crates/xodus-cli/src/main.rs
+++ b/crates/xodus-cli/src/main.rs
@@ -120,7 +120,7 @@ fn main() -> ExitCode {
         if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
             // SAFETY: main() is still single-threaded here, before the tokio
             // runtime exists so there's no concurrent reader of the enviroment
-            unsafe {std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1")} ;
+            unsafe { std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1") };
         }
     }
 


### PR DESCRIPTION
## Problem
`xodus-cli login` hangs/crashes on Linux under wlroots-based compositors
(Hyprland, Sway) with repeated `Failed to create GBM buffer of size
500x700: Invalid argument` — WebKitGTK's DMA-BUF renderer (default since
2.42) fails silently on these compositors, so the login webview never
renders and the login flow can't complete.

## Fix
`WEBKIT_DISABLE_DMABUF_RENDERER=1` works around this, and was already
being set in `main()`. However, `#[tokio::main]` builds the tokio
runtime (and its worker threads) *before* the function body runs, so
the `unsafe { std::env::set_var(...) }` call was executing after other
threads could already exist — undermining its own safety justification
(set_var's unsafety is specifically about races with concurrent env
reads).

This PR switches to a manually-built `tokio::runtime::Runtime`, so the
env var is set while the process is still guaranteed single-threaded,
before `block_on` spins up any workers.

## Testing
- Confirmed `cargo run login` completes successfully on Hyprland
  (previously failed with the GBM error above)
- `cargo build` / existing tests still pass
- No behavior change on non-Linux platforms (env var already gated to
  `target_os = "linux"`)