### PR TITLE
Improve MSIXVC layout handling [1/2]

### DIFF
--- a/crates/msixvc/src/crypt.rs
+++ b/crates/msixvc/src/crypt.rs
@@ -1,4 +1,5 @@
-use crate::models::xvd::{PAGE_SIZE, XvcRegionId};
+use crate::layout::PAGE_SIZE;
+use crate::models::xvd::XvcRegionId;
 
 use std::iter;
 

--- a/crates/msixvc/src/layout.rs
+++ b/crates/msixvc/src/layout.rs
@@ -1,0 +1,74 @@
+use std::ops::{Add, Sub};
+
+pub const PAGE_SIZE: usize = 0x1000;
+pub const BLOCK_SIZE: usize = 0xAA000;
+pub const SECTOR_SIZE: usize = 4096;
+pub const LEGACY_SECTOR_SIZE: usize = 512;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Pages(pub u64);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Bytes(pub u64);
+
+impl Pages {
+    /// Returns the number of bytes that this many pages span.
+    pub fn to_bytes(self) -> Bytes {
+        Bytes(self.0 * PAGE_SIZE as u64)
+    }
+}
+
+impl Bytes {
+    /// Returns whether the byte offset is page-aligned or not.
+    pub fn is_page_aligned(self) -> bool {
+        self.0.is_multiple_of(PAGE_SIZE as u64)
+    }
+
+    /// Returns the index of the page to which the byte offset belongs.
+    pub fn to_page_index(self) -> Pages {
+        Pages(self.0 / PAGE_SIZE as u64)
+    }
+
+    /// Returns the number of pages that this many bytes span.
+    pub fn to_page_count(self) -> Pages {
+        Pages(self.0.div_ceil(PAGE_SIZE as u64))
+    }
+
+    /// If the byte offset is page-aligned then returns its page index, else
+    /// returns `None`.
+    pub fn to_page_index_aligned(self) -> Option<Pages> {
+        self.is_page_aligned().then(|| self.to_page_index())
+    }
+}
+
+impl Add<Pages> for Pages {
+    type Output = Pages;
+
+    fn add(self, rhs: Pages) -> Self::Output {
+        Pages(self.0 + rhs.0)
+    }
+}
+
+impl Add<Bytes> for Bytes {
+    type Output = Bytes;
+
+    fn add(self, rhs: Bytes) -> Self::Output {
+        Bytes(self.0 + rhs.0)
+    }
+}
+
+impl Sub<Pages> for Pages {
+    type Output = Pages;
+
+    fn sub(self, rhs: Pages) -> Self::Output {
+        Pages(self.0 - rhs.0)
+    }
+}
+
+impl Sub<Bytes> for Bytes {
+    type Output = Bytes;
+
+    fn sub(self, rhs: Bytes) -> Self::Output {
+        Bytes(self.0 - rhs.0)
+    }
+}

--- a/crates/msixvc/src/layout.rs
+++ b/crates/msixvc/src/layout.rs
@@ -5,6 +5,8 @@ pub const BLOCK_SIZE: usize = 0xAA000;
 pub const SECTOR_SIZE: usize = 4096;
 pub const LEGACY_SECTOR_SIZE: usize = 512;
 
+pub const PAGES_PER_BLOCK: usize = BLOCK_SIZE / PAGE_SIZE;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Pages(pub u64);
 

--- a/crates/msixvc/src/lib.rs
+++ b/crates/msixvc/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod crypt;
+pub mod layout;
 pub mod math;
 pub mod models;
 pub mod streaming;

--- a/crates/msixvc/src/math.rs
+++ b/crates/msixvc/src/math.rs
@@ -1,37 +1,13 @@
+use crate::layout::Pages;
 use crate::models::xvd::{
-    BLOCK_SIZE, DATA_BLOCKS_IN_LEVEL0_HASHTREE, DATA_BLOCKS_IN_LEVEL1_HASHTREE,
-    DATA_BLOCKS_IN_LEVEL2_HASHTREE, DATA_BLOCKS_IN_LEVEL3_HASHTREE, HASH_ENTRIES_IN_PAGE,
-    LEGACY_SECTOR_SIZE, PAGE_SIZE, PAGES_PER_BLOCK, SECTOR_SIZE,
+    DATA_BLOCKS_IN_LEVEL0_HASHTREE, DATA_BLOCKS_IN_LEVEL1_HASHTREE, DATA_BLOCKS_IN_LEVEL2_HASHTREE,
+    DATA_BLOCKS_IN_LEVEL3_HASHTREE, HASH_ENTRIES_IN_PAGE, PAGES_PER_BLOCK,
 };
-
-pub fn bytes_to_pages(bytes: u64) -> u64 {
-    bytes.div_ceil(PAGE_SIZE as u64)
-}
-
-pub fn offset_to_block_number(offset: u64) -> u64 {
-    offset / BLOCK_SIZE as u64
-}
-
-pub fn offset_to_page_number(offset: u64) -> u64 {
-    offset / PAGE_SIZE as u64
-}
-
-pub fn sectors_to_bytes(sectors: u64) -> u64 {
-    sectors * SECTOR_SIZE as u64
-}
-
-pub fn legacy_sectors_to_bytes(sectors: u64) -> u64 {
-    sectors * LEGACY_SECTOR_SIZE as u64
-}
-
-pub fn page_number_to_offset(page_number: u64) -> u64 {
-    page_number * PAGE_SIZE as u64
-}
 
 pub fn calculate_hash_block_num_and_run_for_block_num(
     xvd_type: u32,
     hash_tree_levels: u64,
-    number_of_hashed_pages: u64,
+    number_of_hashed_pages: Pages,
     block_num: u64,
     hash_level: u32,
     resilient: bool,
@@ -56,17 +32,17 @@ pub fn calculate_hash_block_num_and_run_for_block_num(
     let mut remaining_hash_tree_levels = hash_tree_levels - u64::from(hash_level + 1);
 
     if hash_level == 0 && remaining_hash_tree_levels > 0 {
-        result += number_of_hashed_pages.div_ceil(hash_block_exponent(2));
+        result += number_of_hashed_pages.0.div_ceil(hash_block_exponent(2));
         remaining_hash_tree_levels -= 1;
     }
 
     if (hash_level == 0 || hash_level == 1) && remaining_hash_tree_levels > 0 {
-        result += number_of_hashed_pages.div_ceil(hash_block_exponent(3));
+        result += number_of_hashed_pages.0.div_ceil(hash_block_exponent(3));
         remaining_hash_tree_levels -= 1;
     }
 
     if remaining_hash_tree_levels > 0 {
-        result += number_of_hashed_pages.div_ceil(hash_block_exponent(4));
+        result += number_of_hashed_pages.0.div_ceil(hash_block_exponent(4));
     }
 
     if resilient {

--- a/crates/msixvc/src/math.rs
+++ b/crates/msixvc/src/math.rs
@@ -1,7 +1,7 @@
-use crate::layout::Pages;
+use crate::layout::{PAGES_PER_BLOCK, Pages};
 use crate::models::xvd::{
     DATA_BLOCKS_IN_LEVEL0_HASHTREE, DATA_BLOCKS_IN_LEVEL1_HASHTREE, DATA_BLOCKS_IN_LEVEL2_HASHTREE,
-    DATA_BLOCKS_IN_LEVEL3_HASHTREE, HASH_ENTRIES_IN_PAGE, PAGES_PER_BLOCK,
+    DATA_BLOCKS_IN_LEVEL3_HASHTREE, HASH_ENTRIES_IN_PAGE,
 };
 
 pub fn calculate_hash_block_num_and_run_for_block_num(

--- a/crates/msixvc/src/models/xvd/constants.rs
+++ b/crates/msixvc/src/models/xvd/constants.rs
@@ -1,18 +1,15 @@
+use crate::layout::PAGE_SIZE;
+
 pub const HEADER_SIGNATURE_SIZE: u64 = 0x200;
 pub const XVD_HEADER_SIZE: u64 = 0x2E00;
 pub const XVD_HEADER_INCL_SIGNATURE_SIZE: u64 = HEADER_SIGNATURE_SIZE + XVD_HEADER_SIZE;
 
-pub const PAGE_SIZE: usize = 0x1000;
-pub const BLOCK_SIZE: usize = 0xAA000;
-pub const SECTOR_SIZE: usize = 4096;
-pub const LEGACY_SECTOR_SIZE: usize = 512;
 pub const INVALID_SECTOR: u32 = 0xFFFFFFFF;
 
 pub const HASH_ENTRY_LENGTH: usize = 0x18;
 pub const HASH_ENTRY_LENGTH_ENCRYPTED: usize = 0x14;
 
 pub const HASH_ENTRIES_IN_PAGE: usize = PAGE_SIZE / HASH_ENTRY_LENGTH;
-pub const PAGES_PER_BLOCK: usize = BLOCK_SIZE / PAGE_SIZE;
 
 pub const DATA_BLOCKS_IN_LEVEL0_HASHTREE: usize = HASH_ENTRIES_IN_PAGE;
 pub const DATA_BLOCKS_IN_LEVEL1_HASHTREE: usize =

--- a/crates/msixvc/src/models/xvd/structs.rs
+++ b/crates/msixvc/src/models/xvd/structs.rs
@@ -1,10 +1,9 @@
 use super::{
-    LEGACY_SECTOR_SIZE, PAGE_SIZE, SECTOR_SIZE, WriteablePolicyFlags,
-    XVD_HEADER_INCL_SIGNATURE_SIZE, XvcInfoFlags, XvcRegionFlags, XvcRegionId,
-    XvcRegionPresenceInfoFlags, XvdContentType, XvdSegmentMetadataSegmentFlags, XvdType,
-    XvdVolumeFlags,
+    WriteablePolicyFlags, XVD_HEADER_INCL_SIGNATURE_SIZE, XvcInfoFlags, XvcRegionFlags,
+    XvcRegionId, XvcRegionPresenceInfoFlags, XvdContentType, XvdSegmentMetadataSegmentFlags,
+    XvdType, XvdVolumeFlags,
 };
-use crate::layout::{Bytes, Pages};
+use crate::layout::{Bytes, LEGACY_SECTOR_SIZE, PAGE_SIZE, Pages, SECTOR_SIZE};
 use crate::math::calculate_number_of_hash_pages;
 
 use msixvc_common::parse::byteorder::little_endian::*;

--- a/crates/msixvc/src/models/xvd/structs.rs
+++ b/crates/msixvc/src/models/xvd/structs.rs
@@ -4,7 +4,8 @@ use super::{
     XvcRegionPresenceInfoFlags, XvdContentType, XvdSegmentMetadataSegmentFlags, XvdType,
     XvdVolumeFlags,
 };
-use crate::math::{bytes_to_pages, calculate_number_of_hash_pages, page_number_to_offset};
+use crate::layout::{Bytes, Pages};
+use crate::math::calculate_number_of_hash_pages;
 
 use msixvc_common::parse::byteorder::little_endian::*;
 use msixvc_common::parse::structs::{Filetime, Version};
@@ -29,17 +30,17 @@ pub struct XvdHeader {
     pub volume_flags: XvdVolumeFlags,
     pub format_version: u32,
     pub file_time_created: DateTime<chrono::Utc>,
-    pub drive_size: u64,
+    pub drive_size: Bytes,
     pub vduid: Uuid,
     pub uduid: Uuid,
     pub top_hash_block_hash: [u8; 0x20],
     pub original_xvc_data_hash: [u8; 0x20],
     pub xvd_type: XvdType,
     pub xvd_content_type: XvdContentType,
-    pub embedded_xvd_length: u32,
-    pub user_data_length: u32,
-    pub xvc_data_length: u32,
-    pub dynamic_header_length: u32,
+    pub embedded_xvd_length: Bytes,
+    pub user_data_length: Bytes,
+    pub xvc_data_length: Bytes,
+    pub dynamic_header_length: Bytes,
     pub block_size: u32,
     pub ext_entries: [XvdExtEntry; 0x4],
     pub capabilities: [u16; 0x8],
@@ -56,7 +57,7 @@ pub struct XvdHeader {
     pub writeable_expiration_date: u32,
     pub writeable_policy_flags: WriteablePolicyFlags,
     pub persistent_local_storage_size: u32,
-    pub mutable_page_count: u8,
+    pub mutable_page_count: Pages,
     pub sequence_number: i64,
     pub required_system_version: Version,
     pub odk_keyslot_id: u32,
@@ -151,17 +152,17 @@ impl BinaryTryParse for XvdHeader {
                 volume_flags,
                 format_version,
                 file_time_created,
-                drive_size,
+                drive_size: Bytes(drive_size),
                 vduid,
                 uduid,
                 top_hash_block_hash,
                 original_xvc_data_hash,
                 xvd_type,
                 xvd_content_type,
-                embedded_xvd_length,
-                user_data_length,
-                xvc_data_length,
-                dynamic_header_length,
+                embedded_xvd_length: Bytes(embedded_xvd_length as u64),
+                user_data_length: Bytes(user_data_length as u64),
+                xvc_data_length: Bytes(xvc_data_length as u64),
+                dynamic_header_length: Bytes(dynamic_header_length as u64),
                 block_size,
                 ext_entries,
                 capabilities,
@@ -178,7 +179,7 @@ impl BinaryTryParse for XvdHeader {
                 writeable_expiration_date,
                 writeable_policy_flags,
                 persistent_local_storage_size,
-                mutable_page_count,
+                mutable_page_count: Pages(mutable_page_count as u64),
                 sequence_number,
                 required_system_version,
                 odk_keyslot_id,
@@ -412,10 +413,8 @@ pub struct XvcRegionHeader {
     pub flags: XvcRegionFlags,
     pub first_segment_index: u32,
     pub description: [u16; 0x20], // UTF-16
-    // Multiple of PAGE_SIZE
-    pub offset: u64,
-    // Multiple of PAGE_SIZE
-    pub length: u64,
+    pub offset: Pages,
+    pub length: Pages,
     pub hash: u64,
 }
 
@@ -449,13 +448,13 @@ impl BinaryTryParse for XvcRegionHeader {
         let (offset, r) = r.read::<U64>();
         let (length, r) = r.read::<U64>();
 
-        if !offset.is_multiple_of(PAGE_SIZE as u64) {
-            return Err(Self::Error::InvalidOffset(offset));
-        }
+        let offset = Bytes(offset)
+            .to_page_index_aligned()
+            .ok_or(Self::Error::InvalidOffset(offset))?;
 
-        if !length.is_multiple_of(PAGE_SIZE as u64) {
-            return Err(Self::Error::InvalidLength(length));
-        }
+        let length = Bytes(length)
+            .to_page_index_aligned()
+            .ok_or(Self::Error::InvalidLength(length))?;
 
         let (hash, r) = r.read::<U64>();
 
@@ -662,38 +661,38 @@ impl BinaryParse for XvdSegmentMetadataSegment {
 }
 
 impl XvdHeader {
-    pub fn mutable_data_length(&self) -> u64 {
-        page_number_to_offset(self.mutable_page_count as u64)
+    pub fn mutable_data_length(&self) -> Bytes {
+        self.mutable_page_count.to_bytes()
     }
 
-    pub fn user_data_page_count(&self) -> u64 {
-        bytes_to_pages(self.user_data_length as u64)
+    pub fn user_data_page_count(&self) -> Pages {
+        self.user_data_length.to_page_count()
     }
 
-    pub fn xvc_data_page_count(&self) -> u64 {
-        bytes_to_pages(self.xvc_data_length as u64)
+    pub fn xvc_data_page_count(&self) -> Pages {
+        self.xvc_data_length.to_page_count()
     }
 
-    pub fn embedded_xvd_page_count(&self) -> u64 {
-        bytes_to_pages(self.embedded_xvd_length as u64)
+    pub fn embedded_xvd_page_count(&self) -> Pages {
+        self.embedded_xvd_length.to_page_count()
     }
 
-    pub fn dynamic_header_page_count(&self) -> u64 {
-        bytes_to_pages(self.dynamic_header_length as u64)
+    pub fn dynamic_header_page_count(&self) -> Pages {
+        self.dynamic_header_length.to_page_count()
     }
 
-    pub fn drive_page_count(&self) -> u64 {
-        bytes_to_pages(self.drive_size)
+    pub fn drive_page_count(&self) -> Pages {
+        self.drive_size.to_page_count()
     }
 
-    pub fn number_of_hashed_pages(&self) -> u64 {
+    pub fn number_of_hashed_pages(&self) -> Pages {
         self.drive_page_count()
             + self.user_data_page_count()
             + self.xvc_data_page_count()
             + self.dynamic_header_page_count()
     }
 
-    pub fn number_of_metadata_pages(&self) -> u64 {
+    pub fn number_of_metadata_pages(&self) -> Pages {
         self.user_data_page_count() + self.xvc_data_page_count() + self.dynamic_header_page_count()
     }
 
@@ -705,33 +704,34 @@ impl XvdHeader {
         }
     }
 
-    pub fn mdu_offset(&self) -> u64 {
-        page_number_to_offset(self.embedded_xvd_page_count()) + XVD_HEADER_INCL_SIGNATURE_SIZE
+    pub fn mdu_offset(&self) -> Bytes {
+        self.embedded_xvd_page_count().to_bytes() + Bytes(XVD_HEADER_INCL_SIGNATURE_SIZE)
     }
 
-    pub fn hash_tree_offset(&self) -> u64 {
+    pub fn hash_tree_offset(&self) -> Bytes {
         self.mutable_data_length() + self.mdu_offset()
     }
 
-    pub fn hash_tree_info(&self) -> (u64, u64) {
-        calculate_number_of_hash_pages(
-            self.number_of_hashed_pages(),
+    pub fn hash_tree_info(&self) -> (u64, Pages) {
+        let (levels, pages) = calculate_number_of_hash_pages(
+            self.number_of_hashed_pages().0,
             self.volume_flags.is_resiliency_enabled(),
-        )
+        );
+
+        (levels, Pages(pages))
     }
 
-    pub fn user_data_offset(&self, hash_tree_page_count: u64) -> u64 {
+    pub fn user_data_offset(&self, hash_tree_page_count: Pages) -> Bytes {
         let hash_pages_offset = if self.volume_flags.is_data_integrity_enabled() {
-            page_number_to_offset(hash_tree_page_count)
+            hash_tree_page_count.to_bytes()
         } else {
-            0
+            Bytes(0)
         };
 
         hash_pages_offset + self.hash_tree_offset()
     }
 
-    pub fn xvc_info_offset(&self, hash_tree_page_count: u64) -> u64 {
-        page_number_to_offset(self.user_data_page_count())
-            + self.user_data_offset(hash_tree_page_count)
+    pub fn xvc_info_offset(&self, hash_tree_page_count: Pages) -> Bytes {
+        self.user_data_page_count().to_bytes() + self.user_data_offset(hash_tree_page_count)
     }
 }

--- a/crates/msixvc/src/xvd.rs
+++ b/crates/msixvc/src/xvd.rs
@@ -19,12 +19,12 @@ use uuid::Uuid;
 use zerocopy::IntoBytes;
 
 use crate::crypt::{TweakGenerator, decrypt_page_xts};
-use crate::layout::{Bytes, Pages};
+use crate::layout::{Bytes, PAGE_SIZE, PAGES_PER_BLOCK, Pages};
 use crate::math::calculate_hash_block_num_and_run_for_block_num;
 use crate::models::xvd::{
-    PAGE_SIZE, PAGES_PER_BLOCK, XvcInfo, XvcRegionHeader, XvcRegionId, XvdHashEntry, XvdHeader,
-    XvdSegmentMetadataHeader, XvdSegmentMetadataSegment, XvdSegmentMetadataSegmentFlags,
-    XvdUserDataHeader, XvdUserDataPackageFileEntry, XvdUserDataPackageFilesHeader,
+    XvcInfo, XvcRegionHeader, XvcRegionId, XvdHashEntry, XvdHeader, XvdSegmentMetadataHeader,
+    XvdSegmentMetadataSegment, XvdSegmentMetadataSegmentFlags, XvdUserDataHeader,
+    XvdUserDataPackageFileEntry, XvdUserDataPackageFilesHeader,
 };
 use crate::streaming_ntfs::collect_ntfs_stream_layouts;
 

--- a/crates/msixvc/src/xvd.rs
+++ b/crates/msixvc/src/xvd.rs
@@ -5,7 +5,6 @@ use std::io::{self, Error, ErrorKind, Read, Seek, SeekFrom, Write};
 
 use aes::cipher::KeyInit;
 use aes::{Aes128Dec, Aes128Enc};
-use bytes::Bytes;
 use futures_util::StreamExt;
 use msixvc_common::parse::{BinaryParse, BinaryTryParse};
 use reqwest::header::RANGE;
@@ -20,10 +19,8 @@ use uuid::Uuid;
 use zerocopy::IntoBytes;
 
 use crate::crypt::{TweakGenerator, decrypt_page_xts};
-use crate::math::{
-    bytes_to_pages, calculate_hash_block_num_and_run_for_block_num, offset_to_page_number,
-    page_number_to_offset,
-};
+use crate::layout::{Bytes, Pages};
+use crate::math::calculate_hash_block_num_and_run_for_block_num;
 use crate::models::xvd::{
     PAGE_SIZE, PAGES_PER_BLOCK, XvcInfo, XvcRegionHeader, XvcRegionId, XvdHashEntry, XvdHeader,
     XvdSegmentMetadataHeader, XvdSegmentMetadataSegment, XvdSegmentMetadataSegmentFlags,
@@ -358,8 +355,8 @@ impl XvdFile {
         let mut region_headers: Vec<XvcRegionHeader> = Vec::new();
 
         // TODO: Check if we have proper content type
-        if xvd_header.xvc_data_length > 0 {
-            file.seek(std::io::SeekFrom::Start(xvc_info_offset))
+        if xvd_header.xvc_data_length > Bytes(0) {
+            file.seek(std::io::SeekFrom::Start(xvc_info_offset.0))
                 .await
                 .expect("Unable to seek");
 
@@ -383,30 +380,27 @@ impl XvdFile {
 
         let hash_tree_offset = xvd_header.mutable_data_length() + mdu_offset;
         let user_data_offset = if xvd_header.volume_flags.is_data_integrity_enabled() {
-            page_number_to_offset(xvd_header.hash_tree_info().1)
+            xvd_header.hash_tree_info().1.to_bytes()
         } else {
-            0
+            Bytes(0)
         } + hash_tree_offset;
-        let xvc_info_offset =
-            page_number_to_offset(xvd_header.user_data_page_count()) + user_data_offset;
-        let dynamic_header_offset =
-            page_number_to_offset(xvd_header.xvc_data_page_count()) + xvc_info_offset;
+        let xvc_info_offset = xvd_header.user_data_page_count().to_bytes() + user_data_offset;
+        let dynamic_header_offset = xvd_header.xvc_data_page_count().to_bytes() + xvc_info_offset;
         let drive_data_offset =
-            page_number_to_offset(xvd_header.dynamic_header_page_count()) + dynamic_header_offset;
+            xvd_header.dynamic_header_page_count().to_bytes() + dynamic_header_offset;
 
         let mut enc_sections: Vec<EncryptedSectionInfo> = vec![];
         let mut reader = BufReader::with_capacity(PAGES_PER_BLOCK * XvdHashEntry::SIZE, file);
         for h in region_headers {
             let key_id = h.key_id;
-            let length = h.length;
+            let num_pages = h.length.0;
             match key_id.get() {
                 None => continue,
                 Some(0) => (),
                 Some(n) => todo!("KeyID other than 0 or unencrypted is not supported, found {n}"),
             }
 
-            let start_page = offset_to_page_number(h.offset - user_data_offset);
-            let num_pages = bytes_to_pages(length);
+            let start_page = h.offset - user_data_offset.to_page_index();
             let mut data_units: Vec<u32> = Vec::with_capacity(num_pages as usize);
             let mut data_hashs: Vec<[u8; 20]> = Vec::with_capacity(num_pages as usize);
 
@@ -420,7 +414,7 @@ impl XvdFile {
                         xvd_header.xvd_type as u32,
                         _hash_tree_levels,
                         xvd_header.number_of_hashed_pages(),
-                        start_page + page,
+                        start_page.0 + page,
                         0,
                         false,
                         false,
@@ -428,9 +422,9 @@ impl XvdFile {
                 let run_length = min(run_length, num_pages - page);
                 page += run_length;
                 let read_offset = hash_tree_offset
-                    + page_number_to_offset(hash_block)
-                    + (entry_start * XvdHashEntry::SIZE as u64);
-                reader.seek(SeekFrom::Start(read_offset)).await?;
+                    + Pages(hash_block).to_bytes()
+                    + Bytes(entry_start * XvdHashEntry::SIZE as u64);
+                reader.seek(SeekFrom::Start(read_offset.0)).await?;
 
                 let mut buf = XvdHashEntry::buffer();
                 for _ in 0..run_length {
@@ -442,8 +436,8 @@ impl XvdFile {
             }
 
             enc_sections.push(EncryptedSectionInfo {
-                section_offset: h.offset,
-                section_length: h.length,
+                section_offset: h.offset.to_bytes().0,
+                section_length: h.length.to_bytes().0,
                 header_id: h.region_id,
                 vduid: xvd_header.vduid,
                 data_units: Some(data_units),
@@ -453,9 +447,9 @@ impl XvdFile {
         }
         Ok(XvdFile {
             header: xvd_header,
-            drive_data_offset,
+            drive_data_offset: drive_data_offset.0,
             encrypted_section_infos: enc_sections,
-            user_data_offset,
+            user_data_offset: user_data_offset.0,
         })
     }
 
@@ -660,7 +654,7 @@ impl XvdFile {
     {
         let drive_data_offset = self.drive_data_offset;
         let drive_size = self.header.drive_size;
-        let drive_plain_len = self.non_encrypted_prefix_len(drive_data_offset, drive_size);
+        let drive_plain_len = self.non_encrypted_prefix_len(drive_data_offset, drive_size.0);
 
         block_in_place(|| {
             let block_size = 4096;
@@ -835,7 +829,7 @@ impl XvdFile {
             } else {
                 Ok(None)
             };
-            let data: Bytes;
+            let data;
             if let Ok(Some(Ok(b))) = next {
                 data = b;
             } else {

--- a/crates/xodus-cli/src/commands/run.rs
+++ b/crates/xodus-cli/src/commands/run.rs
@@ -3,7 +3,7 @@ use std::os::fd::{AsFd, IntoRawFd};
 use std::path::Path;
 use std::process::ExitCode;
 
-use msixvc::models::xvd::PAGE_SIZE;
+use msixvc::layout::PAGE_SIZE;
 use msixvc::xvd::{SegmentFile, XvdFile};
 use nix::sys::signal::{Signal, kill};
 use nix::unistd::Pid;


### PR DESCRIPTION
This is the first step towards a better handling of the layout of MSIXVC binaries.

This PR adds a new `layout` module, which contains the `Bytes` and `Pages` structs. Both structs are newtype wrappers over an u64 and have associated methods for converting between them (`Bytes` to `Pages` have two conversions, one for flooring and other for ceiling, while `Pages` to `Bytes` has only one). The `PAGE_SIZE` and similar constants have been moved to the `layout` module. The idea is to have a type-level distinction between a number of bytes and a number of pages, and also allows removing some functions converting bytes to pages and vice versa from the `math` module.

The next step would be precomputing the layout of a MSIXVC binary based on the header into a `XvdLayout` struct, and storing the layout alongside the header into `XvdFile`. This layout struct would contain the page range of each section of the file (MDU, drive, xvc info, etc.). I'm still unsure about how to store the layout, so I'll send the changes in a later patch.