### PR TITLE
Improve MSIXVC layout handling [2/2]

### DIFF
--- a/crates/msixvc-common/src/parse/byteorder.rs
+++ b/crates/msixvc-common/src/parse/byteorder.rs
@@ -10,10 +10,10 @@ use typenum::{U2, U4, U8, U16};
 
 use std::marker::PhantomData;
 
-/// Marker type for parsing little-endian integers though [`BinaryParse`].
+/// Marker type for parsing little-endian integers through [`BinaryParse`].
 pub struct Le<T>(PhantomData<T>);
 
-/// Marker type for parsing big-endian integers though [`BinaryParse`].
+/// Marker type for parsing big-endian integers through [`BinaryParse`].
 pub struct Be<T>(PhantomData<T>);
 
 macro_rules! impl_le_be {

--- a/crates/msixvc/src/layout.rs
+++ b/crates/msixvc/src/layout.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Sub};
+use std::ops::{Add, AddAssign, Sub};
 
 pub const PAGE_SIZE: usize = 0x1000;
 pub const BLOCK_SIZE: usize = 0xAA000;
@@ -74,6 +74,18 @@ impl Add<Bytes> for Bytes {
 
     fn add(self, rhs: Bytes) -> Self::Output {
         Bytes(self.0 + rhs.0)
+    }
+}
+
+impl AddAssign for Pages {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0
+    }
+}
+
+impl AddAssign for Bytes {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0
     }
 }
 

--- a/crates/msixvc/src/layout.rs
+++ b/crates/msixvc/src/layout.rs
@@ -1,4 +1,8 @@
+use std::marker::PhantomData;
 use std::ops::{Add, AddAssign, Sub};
+
+use msixvc_common::parse::byteorder::{Be, Le};
+use msixvc_common::parse::{BinaryParse, BytesReader, EmptyReader};
 
 pub const PAGE_SIZE: usize = 0x1000;
 pub const BLOCK_SIZE: usize = 0xAA000;
@@ -108,3 +112,53 @@ impl Sub<Bytes> for Bytes {
         Bytes(self.0 - rhs.0)
     }
 }
+
+/// Marker type for parsing integers through [`BinaryParse`] into a [`Pages`].
+pub struct PagesParse<T>(PhantomData<T>);
+
+/// Marker type for parsing integers through [`BinaryParse`] into a [`Bytes`].
+pub struct BytesParse<T>(PhantomData<T>);
+
+macro_rules! impl_pages_parse {
+    ($int:ty) => {
+        impl BinaryParse for PagesParse<$int> {
+            type Output = Pages;
+            type Size = <$int as BinaryParse>::Size;
+
+            #[inline]
+            fn parse<'a>(r: BytesReader<'a, Self::Size>) -> (Pages, EmptyReader<'a>) {
+                let (n, r) = r.read::<$int>();
+                (Pages(u32::from(n)), r)
+            }
+        }
+    };
+}
+
+macro_rules! impl_bytes_parse {
+    ($int:ty) => {
+        impl BinaryParse for BytesParse<$int> {
+            type Output = Bytes;
+            type Size = <$int as BinaryParse>::Size;
+
+            #[inline]
+            fn parse<'a>(r: BytesReader<'a, Self::Size>) -> (Bytes, EmptyReader<'a>) {
+                let (n, r) = r.read::<$int>();
+                (Bytes(u64::from(n)), r)
+            }
+        }
+    };
+}
+
+impl_pages_parse!(u8);
+impl_pages_parse!(Le<u16>);
+impl_pages_parse!(Be<u16>);
+impl_pages_parse!(Le<u32>);
+impl_pages_parse!(Be<u32>);
+
+impl_bytes_parse!(u8);
+impl_bytes_parse!(Le<u16>);
+impl_bytes_parse!(Be<u16>);
+impl_bytes_parse!(Le<u32>);
+impl_bytes_parse!(Be<u32>);
+impl_bytes_parse!(Le<u64>);
+impl_bytes_parse!(Be<u64>);

--- a/crates/msixvc/src/layout.rs
+++ b/crates/msixvc/src/layout.rs
@@ -33,31 +33,35 @@ pub struct Bytes(
 
 impl Pages {
     /// Returns the number of bytes that this many pages span.
-    pub fn to_bytes(self) -> Bytes {
+    pub const fn to_bytes(self) -> Bytes {
         Bytes((self.0 as u64) * PAGE_SIZE as u64)
     }
 }
 
 impl Bytes {
     /// Returns whether the byte offset is page-aligned or not.
-    pub fn is_page_aligned(self) -> bool {
+    pub const fn is_page_aligned(self) -> bool {
         self.0.is_multiple_of(PAGE_SIZE as u64)
     }
 
     /// Returns the index of the page to which the byte offset belongs.
-    pub fn to_page_index(self) -> Pages {
+    pub const fn to_page_index(self) -> Pages {
         Pages((self.0 / PAGE_SIZE as u64) as u32)
     }
 
     /// Returns the number of pages that this many bytes span.
-    pub fn to_page_count(self) -> Pages {
+    pub const fn to_page_count(self) -> Pages {
         Pages(self.0.div_ceil(PAGE_SIZE as u64) as u32)
     }
 
     /// If the byte offset is page-aligned then returns its page index, else
     /// returns `None`.
-    pub fn to_page_index_aligned(self) -> Option<Pages> {
-        self.is_page_aligned().then(|| self.to_page_index())
+    pub const fn to_page_index_aligned(self) -> Option<Pages> {
+        if self.is_page_aligned() {
+            Some(self.to_page_index())
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/msixvc/src/models/xvd.rs
+++ b/crates/msixvc/src/models/xvd.rs
@@ -3,6 +3,8 @@ mod enums;
 mod flags;
 mod structs;
 
+pub mod layout;
+
 pub use constants::*;
 pub use enums::*;
 pub use flags::*;

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -17,6 +17,19 @@ pub struct XvdSection {
     pub len: Bytes,
 }
 
+/// [`XvdLayout`] describes the layout of an `MSIXVC` file.
+///
+/// Each section is directly consecutive to the next one, and it is guaranteed
+/// that no sections overlap. The sections are, in order:
+///
+/// 1. [`Self::header`]
+/// 2. [`Self::embedded_xvd`]
+/// 3. [`Self::mutable_data`]
+/// 4. [`Self::hash_tree`]
+/// 5. [`Self::user_data`]
+/// 6. [`Self::xvc_info`]
+/// 7. [`Self::dynamic_header`]
+/// 8. [`Self::drive_data`]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct XvdLayout {
     // It is guaranteed that no sections overlap.
@@ -236,6 +249,14 @@ fn hash_tree_level_pages(hashed_pages: Pages) -> Pages {
     Pages(num_hashes.div_ceil(HASH_ENTRIES_IN_PAGE))
 }
 
+/// [`HashTreeLayout`] describes the layout of the hash tree of an `MSIXVC`
+/// file.
+///
+/// The hash tree is used in order to verify the integrity of the remaining
+/// regions of the file. The hash tree levels are stored in order from 3 to 0,
+/// but the levels before 0 are optional. There's no padding between each level.
+///
+/// See [`HashTreeLevel`] for how is each level stored.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HashTreeLayout {
     level3: HashTreeLevel,

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -62,6 +62,8 @@ impl XvdHeader {
             section
         };
 
+        // TODO: what if integrity is disabled?
+
         // Calculate the layout of the hash tree first because it's the only
         // section whose length can't be accessed directly, but has to be
         // calculated.

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -120,8 +120,14 @@ pub struct HashTreeLevel {
     /// the hash table.
     page_range: Range<Pages>,
     /// The number of hash entries stored in this hash tree level, which is
-    /// equal to the number of pages that the hash tree level covers. `num_hashes`
-    /// might be zero for levels 1-3 if the hash tree does not need more levels.
+    /// equal to the number of pages that the hash tree level covers.
+    ///
+    /// The possible values for `num_hashes` are:
+    /// - For level 0: `1..` (the level 0 hash tree must contain at least one
+    ///   hash entry).
+    /// - For levels 1-3: `0` or `2..` (the other levels can't contain only one
+    ///   hash entry, because when there's only one entry it goes in the header
+    ///   instead).
     num_hashes: Pages,
 }
 
@@ -276,5 +282,141 @@ impl HashTreeLayout {
 
     pub fn level0(&self) -> HashTreeLevel {
         self.level0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_level(level: HashTreeLevel, len: Pages, num_hashes: Pages) {
+        assert_eq!(level.page_range.start + len, level.page_range.end);
+        assert_eq!(level.num_hashes, num_hashes);
+    }
+
+    fn assert_empty_level(level: HashTreeLevel) {
+        assert_level(level, Pages(0), Pages(0));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_empty() {
+        HashTreeLayout::new(Pages(0));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_overflow() {
+        HashTreeLayout::new(MAX_HASHED_PAGES + Pages(1));
+    }
+
+    #[test]
+    fn test_single_hashed_page() {
+        // Even when there's a single hashed page, the level 0 tree level
+        // must contain an entry.
+        let layout = HashTreeLayout::new(Pages(1));
+        assert_empty_level(layout.level3);
+        assert_empty_level(layout.level2);
+        assert_empty_level(layout.level1);
+        assert_level(layout.level0, Pages(1), Pages(1));
+    }
+
+    #[test]
+    fn test_level0_boundary() {
+        // While there's less than `HASH_ENTRIES_IN_PAGE` pages, it fits within
+        // a single level 0 page, so the level 1 hash tree is not needed.
+        let layout = HashTreeLayout::new(Pages(HASH_ENTRIES_IN_PAGE));
+        assert_empty_level(layout.level3);
+        assert_empty_level(layout.level2);
+        assert_empty_level(layout.level1);
+        assert_level(layout.level0, Pages(1), Pages(HASH_ENTRIES_IN_PAGE));
+
+        // If there's more than `HASH_ENTRIES_IN_PAGE` pages, it won't fit
+        // within a single level 0 page.
+        let layout = HashTreeLayout::new(Pages(HASH_ENTRIES_IN_PAGE + 1));
+        assert_empty_level(layout.level3);
+        assert_empty_level(layout.level2);
+
+        // The level 1 hash tree must be 1 page long and contain 2 hashes (one
+        // for each level 0 page).
+        assert_level(layout.level1, Pages(1), Pages(2));
+
+        // The level 0 hash tree must be 2 pages long.
+        assert_level(layout.level0, Pages(2), Pages(HASH_ENTRIES_IN_PAGE + 1));
+    }
+
+    #[test]
+    fn test_level1_boundary() {
+        let layout = HashTreeLayout::new(Pages(HASH_ENTRIES_IN_PAGE.pow(2)));
+        assert_empty_level(layout.level3);
+        assert_empty_level(layout.level2);
+        assert_level(layout.level1, Pages(1), Pages(HASH_ENTRIES_IN_PAGE));
+        assert_level(
+            layout.level0,
+            Pages(HASH_ENTRIES_IN_PAGE),
+            Pages(HASH_ENTRIES_IN_PAGE.pow(2)),
+        );
+
+        let layout = HashTreeLayout::new(Pages(HASH_ENTRIES_IN_PAGE.pow(2) + 1));
+        assert_empty_level(layout.level3);
+        assert_level(layout.level2, Pages(1), Pages(2));
+        assert_level(layout.level1, Pages(2), Pages(HASH_ENTRIES_IN_PAGE + 1));
+        assert_level(
+            layout.level0,
+            Pages(HASH_ENTRIES_IN_PAGE + 1),
+            Pages(HASH_ENTRIES_IN_PAGE.pow(2) + 1),
+        );
+    }
+
+    #[test]
+    fn test_level2_boundary() {
+        let layout = HashTreeLayout::new(Pages(HASH_ENTRIES_IN_PAGE.pow(3)));
+        assert_empty_level(layout.level3);
+        assert_level(layout.level2, Pages(1), Pages(HASH_ENTRIES_IN_PAGE));
+        assert_level(
+            layout.level1,
+            Pages(HASH_ENTRIES_IN_PAGE),
+            Pages(HASH_ENTRIES_IN_PAGE.pow(2)),
+        );
+        assert_level(
+            layout.level0,
+            Pages(HASH_ENTRIES_IN_PAGE.pow(2)),
+            Pages(HASH_ENTRIES_IN_PAGE.pow(3)),
+        );
+
+        let layout = HashTreeLayout::new(Pages(HASH_ENTRIES_IN_PAGE.pow(3) + 1));
+        assert_level(layout.level3, Pages(1), Pages(2));
+        assert_level(layout.level2, Pages(2), Pages(HASH_ENTRIES_IN_PAGE + 1));
+        assert_level(
+            layout.level1,
+            Pages(HASH_ENTRIES_IN_PAGE + 1),
+            Pages(HASH_ENTRIES_IN_PAGE.pow(2) + 1),
+        );
+        assert_level(
+            layout.level0,
+            Pages(HASH_ENTRIES_IN_PAGE.pow(2) + 1),
+            Pages(HASH_ENTRIES_IN_PAGE.pow(3) + 1),
+        );
+    }
+
+    #[test]
+    fn test_max() {
+        let layout = HashTreeLayout::new(MAX_HASHED_PAGES);
+        assert_level(layout.level3, Pages(1), Pages(HASH_ENTRIES_IN_PAGE));
+        assert_level(
+            layout.level2,
+            Pages(HASH_ENTRIES_IN_PAGE),
+            Pages(HASH_ENTRIES_IN_PAGE.pow(2)),
+        );
+        assert_level(
+            layout.level1,
+            Pages(HASH_ENTRIES_IN_PAGE.pow(2)),
+            Pages(HASH_ENTRIES_IN_PAGE.pow(3)),
+        );
+        assert_level(
+            layout.level0,
+            Pages(HASH_ENTRIES_IN_PAGE.pow(3)),
+            Pages(HASH_ENTRIES_IN_PAGE.pow(4)),
+        );
     }
 }

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -1,6 +1,13 @@
 use super::XvdHeader;
 use crate::layout::{Bytes, PAGE_SIZE, Pages};
 
+pub const HASH_ENTRY_LENGTH: usize = 0x18;
+pub const HASH_ENTRIES_IN_PAGE: u32 = (PAGE_SIZE / HASH_ENTRY_LENGTH) as u32;
+
+/// Maximum number of pages that the hash tree may cover.
+pub const MAX_HASHED_PAGES: Pages = Pages(HASH_ENTRIES_IN_PAGE.pow(4));
+pub const MAX_HASHED_BYTES: Bytes = MAX_HASHED_PAGES.to_bytes();
+
 #[derive(Clone, Copy, Debug)]
 pub struct XvdSection {
     pub start: Pages,

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -136,10 +136,21 @@ impl HashTreeLevel {
         self.page_range
     }
 
+    /// The number of pages that this hash tree level occupies.
+    pub fn num_pages(&self) -> Pages {
+        self.page_range.end - self.page_range.start
+    }
+
+    /// The number of hash entries stored in this hash tree level. It's equal
+    /// to the number of pages covered by this hash tree level.
     pub fn num_hashes(&self) -> Pages {
         self.num_hashes
     }
 
+    /// Returns an iterator over the "runs" of entries that this hash tree
+    /// level contains.
+    ///
+    /// See [`HashTreeLevelRunIterator`].
     pub fn hash_entry_runs(&self) -> HashTreeLevelRunIterator {
         HashTreeLevelRunIterator {
             num_hashes: self.num_hashes.0,
@@ -290,7 +301,7 @@ mod tests {
     use super::*;
 
     fn assert_level(level: HashTreeLevel, len: Pages, num_hashes: Pages) {
-        assert_eq!(level.page_range.start + len, level.page_range.end);
+        assert_eq!(level.num_pages(), len);
         assert_eq!(level.num_hashes, num_hashes);
     }
 

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -2,7 +2,9 @@ use super::XvdHeader;
 use crate::layout::{Bytes, PAGE_SIZE, Pages};
 
 use std::cmp;
+use std::fmt::{self, Debug};
 use std::iter::FusedIterator;
+use std::marker::PhantomData;
 use std::range::Range;
 
 pub const HASH_ENTRY_LENGTH: usize = 0x18;
@@ -11,10 +13,27 @@ pub const HASH_ENTRIES_IN_PAGE: u32 = (PAGE_SIZE / HASH_ENTRY_LENGTH) as u32;
 /// Maximum number of pages that the hash tree may cover.
 pub const MAX_HASHED_PAGES: Pages = Pages(HASH_ENTRIES_IN_PAGE.pow(4));
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+// Multiple structs in this module have a `marker: PhantomData<()>` field
+// because all its fields are public, but we don't want to allow instantiating
+// those structs from outside the current module.
+
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct XvdSection {
     pub start: Pages,
     pub len: Bytes,
+
+    // Disallow instantiating the struct.
+    marker: PhantomData<()>,
+}
+
+// The `Debug` impl is needed to avoid polluting the output with the `marker` field.
+impl Debug for XvdSection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("XvdSection")
+            .field("start", &self.start)
+            .field("len", &self.len)
+            .finish()
+    }
 }
 
 /// [`XvdLayout`] describes the layout of an `MSIXVC` file.
@@ -25,22 +44,43 @@ pub struct XvdSection {
 /// 1. [`Self::header`]
 /// 2. [`Self::embedded_xvd`]
 /// 3. [`Self::mutable_data`]
-/// 4. [`Self::hash_tree`]
+/// 4. [`Self::hash_tree`]: its layout can be accessed via [`Self::hash_tree_layout`]
 /// 5. [`Self::user_data`]
 /// 6. [`Self::xvc_info`]
 /// 7. [`Self::dynamic_header`]
 /// 8. [`Self::drive_data`]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct XvdLayout {
     // It is guaranteed that no sections overlap.
-    header: XvdSection,
-    embedded_xvd: XvdSection,
-    mutable_data: XvdSection,
-    hash_tree: (XvdSection, HashTreeLayout),
-    user_data: XvdSection,
-    xvc_info: XvdSection,
-    dynamic_header: XvdSection,
-    drive_data: XvdSection,
+    pub header: XvdSection,
+    pub embedded_xvd: XvdSection,
+    pub mutable_data: XvdSection,
+    pub hash_tree: XvdSection,
+    pub hash_tree_layout: HashTreeLayout,
+    pub user_data: XvdSection,
+    pub xvc_info: XvdSection,
+    pub dynamic_header: XvdSection,
+    pub drive_data: XvdSection,
+
+    // Disallow instantiating the struct.
+    marker: PhantomData<()>,
+}
+
+// The `Debug` impl is needed to avoid polluting the output with the `marker` field.
+impl Debug for XvdLayout {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("XvdLayout")
+            .field("header", &self.header)
+            .field("embedded_xvd", &self.embedded_xvd)
+            .field("mutable_data", &self.mutable_data)
+            .field("hash_tree", &self.hash_tree)
+            .field("hash_tree_layout", &self.hash_tree_layout)
+            .field("user_data", &self.user_data)
+            .field("xvc_info", &self.xvc_info)
+            .field("dynamic_header", &self.dynamic_header)
+            .field("drive_data", &self.drive_data)
+            .finish()
+    }
 }
 
 impl XvdHeader {
@@ -57,6 +97,7 @@ impl XvdHeader {
             let section = XvdSection {
                 start: current_page,
                 len,
+                marker: PhantomData,
             };
             current_page += len.to_page_count();
             section
@@ -82,54 +123,14 @@ impl XvdHeader {
             header: header_section,
             embedded_xvd,
             mutable_data,
-            hash_tree: (hash_tree, hash_tree_layout),
+            hash_tree,
+            hash_tree_layout,
             user_data,
             xvc_info,
             dynamic_header,
             drive_data,
+            marker: PhantomData,
         }
-    }
-}
-
-impl XvdLayout {
-    #[inline]
-    pub fn header(&self) -> XvdSection {
-        self.header
-    }
-
-    #[inline]
-    pub fn embedded_xvd(&self) -> XvdSection {
-        self.embedded_xvd
-    }
-
-    #[inline]
-    pub fn mutable_data(&self) -> XvdSection {
-        self.mutable_data
-    }
-
-    #[inline]
-    pub fn hash_tree(&self) -> (XvdSection, HashTreeLayout) {
-        self.hash_tree
-    }
-
-    #[inline]
-    pub fn user_data(&self) -> XvdSection {
-        self.user_data
-    }
-
-    #[inline]
-    pub fn xvc_info(&self) -> XvdSection {
-        self.xvc_info
-    }
-
-    #[inline]
-    pub fn dynamic_header(&self) -> XvdSection {
-        self.dynamic_header
-    }
-
-    #[inline]
-    pub fn drive_data(&self) -> XvdSection {
-        self.drive_data
     }
 }
 
@@ -144,11 +145,11 @@ impl XvdLayout {
 /// The number of hash entries in each "run" can be retrieved via
 /// [`Self::hash_entry_runs`]. See [`HashTreeLevelRunIterator`] for more
 /// information on how to parse the runs.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct HashTreeLevel {
     /// Range of pages that this tree level occupies, relative to the start of
     /// the hash tree.
-    page_range: Range<Pages>,
+    pub page_range: Range<Pages>,
     /// The number of hash entries stored in this hash tree level, which is
     /// equal to the number of pages that the hash tree level covers.
     ///
@@ -158,26 +159,27 @@ pub struct HashTreeLevel {
     /// - For levels 1-3: `0` or `2..` (the other levels can't contain only one
     ///   hash entry, because when there's only one entry it goes in the header
     ///   instead).
-    num_hashes: Pages,
+    pub num_hashes: Pages,
+
+    // Disallow instantiating the struct.
+    marker: PhantomData<()>,
+}
+
+// The `Debug` impl is needed to avoid polluting the output with the `marker` field.
+impl Debug for HashTreeLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HashTreeLevel")
+            .field("page_range", &self.page_range)
+            .field("num_hashes", &self.num_hashes)
+            .finish()
+    }
 }
 
 impl HashTreeLevel {
-    #[inline]
-    pub fn page_range(&self) -> Range<Pages> {
-        self.page_range
-    }
-
     /// The number of pages that this hash tree level occupies.
     #[inline]
     pub fn num_pages(&self) -> Pages {
         self.page_range.end - self.page_range.start
-    }
-
-    /// The number of hash entries stored in this hash tree level. It's equal
-    /// to the number of pages covered by this hash tree level.
-    #[inline]
-    pub fn num_hashes(&self) -> Pages {
-        self.num_hashes
     }
 
     /// Returns an iterator over the "runs" of entries that this hash tree
@@ -259,12 +261,27 @@ fn hash_tree_level_pages(hashed_pages: Pages) -> Pages {
 /// but the levels before 0 are optional. There's no padding between each level.
 ///
 /// See [`HashTreeLevel`] for how is each level stored.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct HashTreeLayout {
-    level3: HashTreeLevel,
-    level2: HashTreeLevel,
-    level1: HashTreeLevel,
-    level0: HashTreeLevel,
+    pub level3: HashTreeLevel,
+    pub level2: HashTreeLevel,
+    pub level1: HashTreeLevel,
+    pub level0: HashTreeLevel,
+
+    // Disallow instantiating the struct.
+    marker: PhantomData<()>,
+}
+
+// The `Debug` impl is needed to avoid polluting the output with the `marker` field.
+impl Debug for HashTreeLayout {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HashTreeLayout")
+            .field("level3", &self.level3)
+            .field("level2", &self.level2)
+            .field("level1", &self.level1)
+            .field("level0", &self.level0)
+            .finish()
+    }
 }
 
 impl HashTreeLayout {
@@ -291,16 +308,19 @@ impl HashTreeLayout {
         let level3 = HashTreeLevel {
             page_range: range(Pages(0), level3_pages),
             num_hashes: stored_hashes(level2_pages),
+            marker: PhantomData,
         };
 
         let level2 = HashTreeLevel {
             page_range: range(level3.page_range.end, level2_pages),
             num_hashes: stored_hashes(level1_pages),
+            marker: PhantomData,
         };
 
         let level1 = HashTreeLevel {
             page_range: range(level2.page_range.end, level1_pages),
             num_hashes: stored_hashes(level0_pages),
+            marker: PhantomData,
         };
 
         let level0 = HashTreeLevel {
@@ -308,6 +328,7 @@ impl HashTreeLayout {
             // Don't use `stored_hashes` here, as the level 0 hash tree always
             // contains at least one entry.
             num_hashes: drive_data_pages,
+            marker: PhantomData,
         };
 
         HashTreeLayout {
@@ -315,6 +336,7 @@ impl HashTreeLayout {
             level2,
             level1,
             level0,
+            marker: PhantomData,
         }
     }
 
@@ -322,26 +344,6 @@ impl HashTreeLayout {
     #[inline]
     pub fn pages(&self) -> Pages {
         self.level0.page_range.end
-    }
-
-    #[inline]
-    pub fn level3(&self) -> HashTreeLevel {
-        self.level3
-    }
-
-    #[inline]
-    pub fn level2(&self) -> HashTreeLevel {
-        self.level2
-    }
-
-    #[inline]
-    pub fn level1(&self) -> HashTreeLevel {
-        self.level1
-    }
-
-    #[inline]
-    pub fn level0(&self) -> HashTreeLevel {
-        self.level0
     }
 }
 

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -125,7 +125,7 @@ impl XvdLayout {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HashTreeLevel {
     /// Range of pages that this tree level occupies, relative to the start of
-    /// the hash table.
+    /// the hash tree.
     page_range: Range<Pages>,
     /// The number of hash entries stored in this hash tree level, which is
     /// equal to the number of pages that the hash tree level covers.
@@ -214,7 +214,7 @@ impl ExactSizeIterator for HashTreeLevelRunIterator {}
 /// as the hash would be stored in the XVD header instead.
 fn stored_hashes(hashed_pages: Pages) -> Pages {
     // If the level only covers one page, its hash is stored directly in the
-    // header instead of the hash table.
+    // header instead of the hash tree.
     if hashed_pages == Pages(1) {
         Pages(0)
     } else {

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -137,7 +137,7 @@ impl XvdHeader {
 /// The layout of a hash tree level.
 ///
 /// Each hash tree level contains the hashes of the pages of the level below it.
-/// For the level 0 it contains the hashes of the pages of the drive data.
+/// For the level 0 it contains the hashes of the pages of the actual data.
 ///
 /// Because the size of each hash entry (24 bytes) is not divisible by
 /// `PAGE_SIZE`, the last 16 bytes of each page are zeroes. For that reason,
@@ -285,13 +285,13 @@ impl Debug for HashTreeLayout {
 }
 
 impl HashTreeLayout {
-    /// `drive_data_pages` must be in the range `1..MAX_HASHED_PAGES`.
-    fn new(drive_data_pages: Pages) -> HashTreeLayout {
-        assert!(drive_data_pages > Pages(0));
-        assert!(drive_data_pages <= MAX_HASHED_PAGES);
+    /// `hashed_pages` must be in the range `1..MAX_HASHED_PAGES`.
+    fn new(hashed_pages: Pages) -> HashTreeLayout {
+        assert!(hashed_pages > Pages(0));
+        assert!(hashed_pages <= MAX_HASHED_PAGES);
 
-        // The level 0 hash tree must always exist, even when there's a single drive data page.
-        let level0_pages = cmp::max(hash_tree_level_pages(drive_data_pages), Pages(1));
+        // The level 0 hash tree must always exist, even when there's a single hashed page.
+        let level0_pages = cmp::max(hash_tree_level_pages(hashed_pages), Pages(1));
         let level1_pages = hash_tree_level_pages(level0_pages);
         let level2_pages = hash_tree_level_pages(level1_pages);
         let level3_pages = hash_tree_level_pages(level2_pages);
@@ -327,7 +327,7 @@ impl HashTreeLayout {
             page_range: range(level1.page_range.end, level0_pages),
             // Don't use `stored_hashes` here, as the level 0 hash tree always
             // contains at least one entry.
-            num_hashes: drive_data_pages,
+            num_hashes: hashed_pages,
             marker: PhantomData,
         };
 

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -31,6 +31,13 @@ pub struct XvdLayout {
 }
 
 impl XvdHeader {
+    pub fn number_of_hashed_pages(&self) -> Pages {
+        self.user_data_length.to_page_count()
+            + self.xvc_data_length.to_page_count()
+            + self.dynamic_header_length.to_page_count()
+            + self.drive_size.to_page_count()
+    }
+
     pub fn layout(&self) -> XvdLayout {
         let mut current_page = Pages(0);
         let mut next_section = |len: Bytes| -> XvdSection {
@@ -45,7 +52,7 @@ impl XvdHeader {
         // Calculate the layout of the hash tree first because it's the only
         // section whose length can't be accessed directly, but has to be
         // calculated.
-        let hash_tree_layout = HashTreeLayout::new(self.drive_size.to_page_count());
+        let hash_tree_layout = HashTreeLayout::new(self.number_of_hashed_pages());
 
         let header_section = next_section(Bytes(PAGE_SIZE as u64 * 3));
         let embedded_xvd = next_section(self.embedded_xvd_length);

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -1,6 +1,10 @@
 use super::XvdHeader;
 use crate::layout::{Bytes, PAGE_SIZE, Pages};
 
+use std::cmp;
+use std::iter::FusedIterator;
+use std::range::Range;
+
 pub const HASH_ENTRY_LENGTH: usize = 0x18;
 pub const HASH_ENTRIES_IN_PAGE: u32 = (PAGE_SIZE / HASH_ENTRY_LENGTH) as u32;
 
@@ -8,19 +12,19 @@ pub const HASH_ENTRIES_IN_PAGE: u32 = (PAGE_SIZE / HASH_ENTRY_LENGTH) as u32;
 pub const MAX_HASHED_PAGES: Pages = Pages(HASH_ENTRIES_IN_PAGE.pow(4));
 pub const MAX_HASHED_BYTES: Bytes = MAX_HASHED_PAGES.to_bytes();
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct XvdSection {
     pub start: Pages,
     pub len: Bytes,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct XvdLayout {
     // It is guaranteed that no sections overlap.
     header: XvdSection,
     embedded_xvd: XvdSection,
     mutable_data: XvdSection,
-    hash_tree: XvdSection,
+    hash_tree: (XvdSection, HashTreeLayout),
     user_data: XvdSection,
     xvc_info: XvdSection,
     dynamic_header: XvdSection,
@@ -39,10 +43,15 @@ impl XvdHeader {
             section
         };
 
+        // Calculate the layout of the hash tree first because it's the only
+        // section whose length can't be accessed directly, but has to be
+        // calculated.
+        let hash_tree_layout = HashTreeLayout::new(self.drive_size.to_page_count());
+
         let header_section = next_section(Bytes(PAGE_SIZE as u64 * 3));
         let embedded_xvd = next_section(self.embedded_xvd_length);
         let mutable_data = next_section(self.mutable_page_count.to_bytes());
-        let hash_tree = todo!();
+        let hash_tree = next_section(hash_tree_layout.pages().to_bytes());
         let user_data = next_section(self.user_data_length);
         let xvc_info = next_section(self.xvc_data_length);
         let dynamic_header = next_section(self.dynamic_header_length);
@@ -52,7 +61,7 @@ impl XvdHeader {
             header: header_section,
             embedded_xvd,
             mutable_data,
-            hash_tree,
+            hash_tree: (hash_tree, hash_tree_layout),
             user_data,
             xvc_info,
             dynamic_header,
@@ -74,7 +83,7 @@ impl XvdLayout {
         self.mutable_data
     }
 
-    pub fn hash_tree(&self) -> XvdSection {
+    pub fn hash_tree(&self) -> (XvdSection, HashTreeLayout) {
         self.hash_tree
     }
 
@@ -92,5 +101,180 @@ impl XvdLayout {
 
     pub fn drive_data(&self) -> XvdSection {
         self.drive_data
+    }
+}
+
+/// The layout of a hash tree level.
+///
+/// Each hash tree level contains the hashes of the pages of the level below it.
+/// For the level 0 it contains the hashes of the pages of the drive data.
+///
+/// Because the size of each hash entry (24 bytes) is not divisible by
+/// `PAGE_SIZE`, the last 16 bytes of each page are zeroes. For that reason,
+/// not all the hashes in the same level are consecutive, but stored in "runs".
+/// The number of hash entries in each "run" can be retrieved via
+/// [`Self::hash_entry_runs`]. See [`HashTreeLevelRunIterator`] for more
+/// information on how to parse the runs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HashTreeLevel {
+    /// Range of pages that this tree level occupies, relative to the start of
+    /// the hash table.
+    page_range: Range<Pages>,
+    /// The number of hash entries stored in this hash tree level, which is
+    /// equal to the number of pages that the hash tree level covers. `num_hashes`
+    /// might be zero for levels 1-3 if the hash tree does not need more levels.
+    num_hashes: Pages,
+}
+
+impl HashTreeLevel {
+    pub fn page_range(&self) -> Range<Pages> {
+        self.page_range
+    }
+
+    pub fn num_hashes(&self) -> Pages {
+        self.num_hashes
+    }
+
+    pub fn hash_entry_runs(&self) -> HashTreeLevelRunIterator {
+        HashTreeLevelRunIterator {
+            num_hashes: self.num_hashes.0,
+        }
+    }
+}
+
+/// An iterator over the number of hash entries in each run of hashes for this
+/// hash tree level.
+///
+/// After reading [`Self::next`] hash entries from the page, the remaining bytes
+/// of the page must be discarded (16 bytes if the page is full of hash entries,
+/// or more if it's the last run).
+#[derive(Debug, PartialEq, Eq)]
+pub struct HashTreeLevelRunIterator {
+    num_hashes: u32,
+}
+
+impl Iterator for HashTreeLevelRunIterator {
+    // `u8` is enough because he maximum run length (`HASH_ENTRIES_IN_PAGE`) is
+    // less than `u8::MAX`
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.num_hashes == 0 {
+            return None;
+        }
+
+        let run_hashes = cmp::min(self.num_hashes, HASH_ENTRIES_IN_PAGE);
+        self.num_hashes -= run_hashes;
+        Some(run_hashes as u8)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let runs = self.num_hashes.div_ceil(HASH_ENTRIES_IN_PAGE) as usize;
+        (runs, Some(runs))
+    }
+}
+
+impl FusedIterator for HashTreeLevelRunIterator {}
+impl ExactSizeIterator for HashTreeLevelRunIterator {}
+
+/// Calculates how many hash entries are stored in the hash tree level, if the
+/// level covers `hashed_pages` many pages.
+///
+/// It returns its input unchanged unless `hashed_pages` is 1, then returns 0,
+/// as the hash would be stored in the XVD header instead.
+fn stored_hashes(hashed_pages: Pages) -> Pages {
+    // If the level only covers one page, its hash is stored directly in the
+    // header instead of the hash table.
+    if hashed_pages == Pages(1) {
+        Pages(0)
+    } else {
+        hashed_pages
+    }
+}
+
+/// Calculates how many pages the hash tree level occupies, given the number of
+/// pages it covers.
+fn hash_tree_level_pages(hashed_pages: Pages) -> Pages {
+    let num_hashes = stored_hashes(hashed_pages).0;
+    Pages(num_hashes.div_ceil(HASH_ENTRIES_IN_PAGE))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HashTreeLayout {
+    level3: HashTreeLevel,
+    level2: HashTreeLevel,
+    level1: HashTreeLevel,
+    level0: HashTreeLevel,
+}
+
+impl HashTreeLayout {
+    /// `drive_data_pages` must be less or equal to `MAX_HASHED_PAGES`.
+    fn new(drive_data_pages: Pages) -> HashTreeLayout {
+        assert!(drive_data_pages <= MAX_HASHED_PAGES);
+
+        // The level 0 hash tree must always exist, even when there's a single drive data page.
+        let level0_pages = cmp::max(hash_tree_level_pages(drive_data_pages), Pages(1));
+        let level1_pages = hash_tree_level_pages(level0_pages);
+        let level2_pages = hash_tree_level_pages(level1_pages);
+        let level3_pages = hash_tree_level_pages(level2_pages);
+
+        // The level 3 hash tree level must be at most one page long.
+        assert!(level3_pages.0 <= 1);
+
+        // Compute the start, number of pages and number of hashes of each level.
+
+        fn range(start: Pages, length: Pages) -> Range<Pages> {
+            Range::from(start..start + length)
+        }
+
+        let level3 = HashTreeLevel {
+            page_range: range(Pages(0), level3_pages),
+            num_hashes: stored_hashes(level2_pages),
+        };
+
+        let level2 = HashTreeLevel {
+            page_range: range(level3.page_range.end, level2_pages),
+            num_hashes: stored_hashes(level1_pages),
+        };
+
+        let level1 = HashTreeLevel {
+            page_range: range(level2.page_range.end, level1_pages),
+            num_hashes: stored_hashes(level0_pages),
+        };
+
+        let level0 = HashTreeLevel {
+            page_range: range(level1.page_range.end, level0_pages),
+            // Don't use `stored_hashes` here, as the level 0 hash tree always
+            // contains at least one entry.
+            num_hashes: drive_data_pages,
+        };
+
+        HashTreeLayout {
+            level3,
+            level2,
+            level1,
+            level0,
+        }
+    }
+
+    /// Returns the length of the hash tree section (in `Pages`).
+    pub fn pages(&self) -> Pages {
+        self.level0.page_range.end
+    }
+
+    pub fn level3(&self) -> HashTreeLevel {
+        self.level3
+    }
+
+    pub fn level2(&self) -> HashTreeLevel {
+        self.level2
+    }
+
+    pub fn level1(&self) -> HashTreeLevel {
+        self.level1
+    }
+
+    pub fn level0(&self) -> HashTreeLevel {
+        self.level0
     }
 }

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -182,6 +182,12 @@ impl HashTreeLevel {
         self.page_range.end - self.page_range.start
     }
 
+    /// Returns whether this hash tree level is the top-most one.
+    #[inline]
+    pub fn is_top(&self) -> bool {
+        self.num_hashes.0 > 0 && self.num_hashes.0 <= HASH_ENTRIES_IN_PAGE
+    }
+
     /// Returns an iterator over the "runs" of entries that this hash tree
     /// level contains.
     ///

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -1,0 +1,55 @@
+use super::XvdHeader;
+use crate::layout::{Bytes, PAGE_SIZE, Pages};
+
+#[derive(Clone, Copy, Debug)]
+pub struct XvdSection {
+    pub start: Pages,
+    pub len: Bytes,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct XvdLayout {
+    // It is guaranteed that no sections overlap.
+    header: XvdSection,
+    embedded_xvd: XvdSection,
+    mutable_data: XvdSection,
+    hash_tree: XvdSection,
+    user_data: XvdSection,
+    xvc_info: XvdSection,
+    dynamic_header: XvdSection,
+    drive_data: XvdSection,
+}
+
+impl XvdHeader {
+    pub fn layout(&self) -> XvdLayout {
+        let mut current_page = Pages(0);
+        let mut next_section = |len: Bytes| -> XvdSection {
+            let section = XvdSection {
+                start: current_page,
+                len,
+            };
+            current_page += len.to_page_count();
+            section
+        };
+
+        let header_section = next_section(Bytes(PAGE_SIZE as u64 * 3));
+        let embedded_xvd = next_section(self.embedded_xvd_length);
+        let mutable_data = next_section(self.mutable_page_count.to_bytes());
+        let hash_tree = todo!();
+        let user_data = next_section(self.user_data_length);
+        let xvc_info = next_section(self.xvc_data_length);
+        let dynamic_header = next_section(self.dynamic_header_length);
+        let drive_data = next_section(self.drive_size);
+
+        XvdLayout {
+            header: header_section,
+            embedded_xvd,
+            mutable_data,
+            hash_tree,
+            user_data,
+            xvc_info,
+            dynamic_header,
+            drive_data,
+        }
+    }
+}

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -351,6 +351,18 @@ impl HashTreeLayout {
     pub fn pages(&self) -> Pages {
         self.level0.page_range.end
     }
+
+    /// Returns the index of the top-most hash tree level.
+    ///
+    /// Add one to get the number of levels in the hash tree.
+    #[inline]
+    pub fn top_level(&self) -> u8 {
+        [self.level0, self.level1, self.level2, self.level3]
+            .into_iter()
+            .position(|l| l.is_top())
+            .map(|n| n as u8)
+            .expect("level 0 must contain at least one hash entry")
+    }
 }
 
 #[cfg(test)]

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -10,7 +10,6 @@ pub const HASH_ENTRIES_IN_PAGE: u32 = (PAGE_SIZE / HASH_ENTRY_LENGTH) as u32;
 
 /// Maximum number of pages that the hash tree may cover.
 pub const MAX_HASHED_PAGES: Pages = Pages(HASH_ENTRIES_IN_PAGE.pow(4));
-pub const MAX_HASHED_BYTES: Bytes = MAX_HASHED_PAGES.to_bytes();
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct XvdSection {
@@ -208,8 +207,9 @@ pub struct HashTreeLayout {
 }
 
 impl HashTreeLayout {
-    /// `drive_data_pages` must be less or equal to `MAX_HASHED_PAGES`.
+    /// `drive_data_pages` must be in the range `1..MAX_HASHED_PAGES`.
     fn new(drive_data_pages: Pages) -> HashTreeLayout {
+        assert!(drive_data_pages > Pages(0));
         assert!(drive_data_pages <= MAX_HASHED_PAGES);
 
         // The level 0 hash tree must always exist, even when there's a single drive data page.

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -53,3 +53,37 @@ impl XvdHeader {
         }
     }
 }
+
+impl XvdLayout {
+    pub fn header(&self) -> XvdSection {
+        self.header
+    }
+
+    pub fn embedded_xvd(&self) -> XvdSection {
+        self.embedded_xvd
+    }
+
+    pub fn mutable_data(&self) -> XvdSection {
+        self.mutable_data
+    }
+
+    pub fn hash_tree(&self) -> XvdSection {
+        self.hash_tree
+    }
+
+    pub fn user_data(&self) -> XvdSection {
+        self.user_data
+    }
+
+    pub fn xvc_info(&self) -> XvdSection {
+        self.xvc_info
+    }
+
+    pub fn dynamic_header(&self) -> XvdSection {
+        self.dynamic_header
+    }
+
+    pub fn drive_data(&self) -> XvdSection {
+        self.drive_data
+    }
+}

--- a/crates/msixvc/src/models/xvd/layout.rs
+++ b/crates/msixvc/src/models/xvd/layout.rs
@@ -70,34 +70,42 @@ impl XvdHeader {
 }
 
 impl XvdLayout {
+    #[inline]
     pub fn header(&self) -> XvdSection {
         self.header
     }
 
+    #[inline]
     pub fn embedded_xvd(&self) -> XvdSection {
         self.embedded_xvd
     }
 
+    #[inline]
     pub fn mutable_data(&self) -> XvdSection {
         self.mutable_data
     }
 
+    #[inline]
     pub fn hash_tree(&self) -> (XvdSection, HashTreeLayout) {
         self.hash_tree
     }
 
+    #[inline]
     pub fn user_data(&self) -> XvdSection {
         self.user_data
     }
 
+    #[inline]
     pub fn xvc_info(&self) -> XvdSection {
         self.xvc_info
     }
 
+    #[inline]
     pub fn dynamic_header(&self) -> XvdSection {
         self.dynamic_header
     }
 
+    #[inline]
     pub fn drive_data(&self) -> XvdSection {
         self.drive_data
     }
@@ -132,17 +140,20 @@ pub struct HashTreeLevel {
 }
 
 impl HashTreeLevel {
+    #[inline]
     pub fn page_range(&self) -> Range<Pages> {
         self.page_range
     }
 
     /// The number of pages that this hash tree level occupies.
+    #[inline]
     pub fn num_pages(&self) -> Pages {
         self.page_range.end - self.page_range.start
     }
 
     /// The number of hash entries stored in this hash tree level. It's equal
     /// to the number of pages covered by this hash tree level.
+    #[inline]
     pub fn num_hashes(&self) -> Pages {
         self.num_hashes
     }
@@ -151,6 +162,7 @@ impl HashTreeLevel {
     /// level contains.
     ///
     /// See [`HashTreeLevelRunIterator`].
+    #[inline]
     pub fn hash_entry_runs(&self) -> HashTreeLevelRunIterator {
         HashTreeLevelRunIterator {
             num_hashes: self.num_hashes.0,
@@ -174,6 +186,7 @@ impl Iterator for HashTreeLevelRunIterator {
     // less than `u8::MAX`
     type Item = u8;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.num_hashes == 0 {
             return None;
@@ -184,6 +197,7 @@ impl Iterator for HashTreeLevelRunIterator {
         Some(run_hashes as u8)
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let runs = self.num_hashes.div_ceil(HASH_ENTRIES_IN_PAGE) as usize;
         (runs, Some(runs))
@@ -275,22 +289,27 @@ impl HashTreeLayout {
     }
 
     /// Returns the length of the hash tree section (in `Pages`).
+    #[inline]
     pub fn pages(&self) -> Pages {
         self.level0.page_range.end
     }
 
+    #[inline]
     pub fn level3(&self) -> HashTreeLevel {
         self.level3
     }
 
+    #[inline]
     pub fn level2(&self) -> HashTreeLevel {
         self.level2
     }
 
+    #[inline]
     pub fn level1(&self) -> HashTreeLevel {
         self.level1
     }
 
+    #[inline]
     pub fn level0(&self) -> HashTreeLevel {
         self.level0
     }

--- a/crates/msixvc/src/models/xvd/structs.rs
+++ b/crates/msixvc/src/models/xvd/structs.rs
@@ -4,7 +4,9 @@ use super::{
     XvcRegionId, XvcRegionPresenceInfoFlags, XvdContentType, XvdSegmentMetadataSegmentFlags,
     XvdType, XvdVolumeFlags,
 };
-use crate::layout::{Bytes, LEGACY_SECTOR_SIZE, PAGE_SIZE, Pages, SECTOR_SIZE};
+use crate::layout::{
+    Bytes, BytesParse, LEGACY_SECTOR_SIZE, PAGE_SIZE, Pages, PagesParse, SECTOR_SIZE,
+};
 use crate::math::calculate_number_of_hash_pages;
 
 use msixvc_common::parse::byteorder::little_endian::*;
@@ -105,9 +107,8 @@ impl BinaryTryParse for XvdHeader {
         let (volume_flags, r) = r.read::<XvdVolumeFlags>();
         let (format_version, r) = r.read::<U32>();
         let (file_time_created, r) = r.read::<Filetime>();
-        let (drive_size, r) = r.read::<U64>();
+        let (drive_size, r) = r.read::<BytesParse<U64>>();
 
-        let drive_size = Bytes(drive_size);
         if !Self::DRIVE_SIZE_RANGE.contains(&drive_size) {
             return Err(Self::Error::InvalidDriveSize { drive_size });
         }
@@ -121,10 +122,10 @@ impl BinaryTryParse for XvdHeader {
         let (xvd_type, r) = r.try_read::<XvdType>()?;
         let (xvd_content_type, r) = r.try_read::<XvdContentType>()?;
 
-        let (embedded_xvd_length, r) = r.read::<U32>();
-        let (user_data_length, r) = r.read::<U32>();
-        let (xvc_data_length, r) = r.read::<U32>();
-        let (dynamic_header_length, r) = r.read::<U32>();
+        let (embedded_xvd_length, r) = r.read::<BytesParse<U32>>();
+        let (user_data_length, r) = r.read::<BytesParse<U32>>();
+        let (xvc_data_length, r) = r.read::<BytesParse<U32>>();
+        let (dynamic_header_length, r) = r.read::<BytesParse<U32>>();
         let (block_size, r) = r.read::<U32>();
 
         let (ext_entries, r) = r.read::<[XvdExtEntry; 4]>();
@@ -147,7 +148,7 @@ impl BinaryTryParse for XvdHeader {
         let (writeable_policy_flags, r) = r.read::<WriteablePolicyFlags>();
 
         let (persistent_local_storage_size, r) = r.read::<U32>();
-        let (mutable_page_count, r) = r.read::<u8>();
+        let (mutable_page_count, r) = r.read::<PagesParse<u8>>();
 
         let (_unknown271, r) = r.read::<u8>();
         let (_unknown272, r) = r.array::<0x10>();
@@ -173,10 +174,10 @@ impl BinaryTryParse for XvdHeader {
                 original_xvc_data_hash,
                 xvd_type,
                 xvd_content_type,
-                embedded_xvd_length: Bytes(embedded_xvd_length as u64),
-                user_data_length: Bytes(user_data_length as u64),
-                xvc_data_length: Bytes(xvc_data_length as u64),
-                dynamic_header_length: Bytes(dynamic_header_length as u64),
+                embedded_xvd_length,
+                user_data_length,
+                xvc_data_length,
+                dynamic_header_length,
                 block_size,
                 ext_entries,
                 capabilities,
@@ -193,7 +194,7 @@ impl BinaryTryParse for XvdHeader {
                 writeable_expiration_date,
                 writeable_policy_flags,
                 persistent_local_storage_size,
-                mutable_page_count: Pages(mutable_page_count as u32),
+                mutable_page_count,
                 sequence_number,
                 required_system_version,
                 odk_keyslot_id,
@@ -434,11 +435,11 @@ pub struct XvcRegionHeader {
 
 #[derive(thiserror::Error, Debug)]
 pub enum XvcRegionHeaderParseError {
-    #[error("invalid offset {0}: must be a multiple of page size ({PAGE_SIZE})")]
-    InvalidOffset(u64),
+    #[error("invalid offset {0:?}: must be a multiple of page size ({PAGE_SIZE})")]
+    InvalidOffset(Bytes),
 
-    #[error("invalid length {0}: must be a multiple of page size ({PAGE_SIZE})")]
-    InvalidLength(u64),
+    #[error("invalid length {0:?}: must be a multiple of page size ({PAGE_SIZE})")]
+    InvalidLength(Bytes),
 }
 
 impl BinaryTryParse for XvcRegionHeader {
@@ -459,14 +460,14 @@ impl BinaryTryParse for XvcRegionHeader {
         let (first_segment_index, r) = r.read::<U32>();
         let (description, r) = r.read::<[U16; 0x20]>();
 
-        let (offset, r) = r.read::<U64>();
-        let (length, r) = r.read::<U64>();
+        let (offset, r) = r.read::<BytesParse<U64>>();
+        let (length, r) = r.read::<BytesParse<U64>>();
 
-        let offset = Bytes(offset)
+        let offset = offset
             .to_page_index_aligned()
             .ok_or(Self::Error::InvalidOffset(offset))?;
 
-        let length = Bytes(length)
+        let length = length
             .to_page_index_aligned()
             .ok_or(Self::Error::InvalidLength(length))?;
 

--- a/crates/msixvc/src/models/xvd/structs.rs
+++ b/crates/msixvc/src/models/xvd/structs.rs
@@ -1,4 +1,4 @@
-use super::layout::MAX_HASHED_BYTES;
+use super::layout::MAX_HASHED_PAGES;
 use super::{
     WriteablePolicyFlags, XVD_HEADER_INCL_SIGNATURE_SIZE, XvcInfoFlags, XvcRegionFlags,
     XvcRegionId, XvcRegionPresenceInfoFlags, XvdContentType, XvdSegmentMetadataSegmentFlags,
@@ -20,6 +20,7 @@ use typenum::{
 use uuid::Uuid;
 
 use std::collections::HashMap;
+use std::range::Range;
 
 type T2900 = Sum<T2048, T852>;
 type T3496 = Diff<T4096, T600>;
@@ -67,6 +68,11 @@ pub struct XvdHeader {
 
 impl XvdHeader {
     const MAGIC: &[u8; 8] = b"msft-xvd";
+    const DRIVE_SIZE_RANGE: Range<Bytes> = Range {
+        // The drive must be at least one page long.
+        start: Bytes(1),
+        end: MAX_HASHED_PAGES.to_bytes(),
+    };
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -80,8 +86,8 @@ pub enum XvdHeaderParseError {
     #[error("invalid xvd content type: {0}")]
     InvalidXvdContentType(#[from] TryFromPrimitiveError<XvdContentType>),
 
-    #[error("too large drive size: {drive_size:?}, the maximum is {MAX_HASHED_BYTES:?}")]
-    TooLargeDriveSize { drive_size: Bytes },
+    #[error("invalid drive size: {drive_size:?}, must be in the range {range:?}", range = XvdHeader::DRIVE_SIZE_RANGE)]
+    InvalidDriveSize { drive_size: Bytes },
 }
 
 impl BinaryTryParse for XvdHeader {
@@ -102,8 +108,8 @@ impl BinaryTryParse for XvdHeader {
         let (drive_size, r) = r.read::<U64>();
 
         let drive_size = Bytes(drive_size);
-        if drive_size > MAX_HASHED_BYTES {
-            return Err(Self::Error::TooLargeDriveSize { drive_size });
+        if !Self::DRIVE_SIZE_RANGE.contains(&drive_size) {
+            return Err(Self::Error::InvalidDriveSize { drive_size });
         }
 
         let (vduid, r) = r.read::<Uuid>();

--- a/crates/msixvc/src/models/xvd/structs.rs
+++ b/crates/msixvc/src/models/xvd/structs.rs
@@ -22,7 +22,6 @@ use typenum::{
 use uuid::Uuid;
 
 use std::collections::HashMap;
-use std::range::Range;
 
 type T2900 = Sum<T2048, T852>;
 type T3496 = Diff<T4096, T600>;
@@ -70,11 +69,6 @@ pub struct XvdHeader {
 
 impl XvdHeader {
     const MAGIC: &[u8; 8] = b"msft-xvd";
-    const DRIVE_SIZE_RANGE: Range<Bytes> = Range {
-        // The drive must be at least one page long.
-        start: Bytes(1),
-        end: MAX_HASHED_PAGES.to_bytes(),
-    };
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -88,8 +82,8 @@ pub enum XvdHeaderParseError {
     #[error("invalid xvd content type: {0}")]
     InvalidXvdContentType(#[from] TryFromPrimitiveError<XvdContentType>),
 
-    #[error("invalid drive size: {drive_size:?}, must be in the range {range:?}", range = XvdHeader::DRIVE_SIZE_RANGE)]
-    InvalidDriveSize { drive_size: Bytes },
+    #[error("invalid hashed pages count: {hashed_pages:?}, must be less than {MAX_HASHED_PAGES:?}")]
+    InvalidHashedPagesCount { hashed_pages: Pages },
 }
 
 impl BinaryTryParse for XvdHeader {
@@ -109,10 +103,6 @@ impl BinaryTryParse for XvdHeader {
         let (file_time_created, r) = r.read::<Filetime>();
         let (drive_size, r) = r.read::<BytesParse<U64>>();
 
-        if !Self::DRIVE_SIZE_RANGE.contains(&drive_size) {
-            return Err(Self::Error::InvalidDriveSize { drive_size });
-        }
-
         let (vduid, r) = r.read::<Uuid>();
         let (uduid, r) = r.read::<Uuid>();
 
@@ -127,6 +117,41 @@ impl BinaryTryParse for XvdHeader {
         let (xvc_data_length, r) = r.read::<BytesParse<U32>>();
         let (dynamic_header_length, r) = r.read::<BytesParse<U32>>();
         let (block_size, r) = r.read::<U32>();
+
+        // Check that the number of hashed pages doesn't exceed the maximum
+        {
+            // All sections except for `drive_size` are parsed as an u32, so
+            // they cannot overflow when adding together. Check the drive size
+            // first, and if it doesn't overflow then check the sum.
+
+            if drive_size > MAX_HASHED_PAGES.to_bytes() {
+                return Err(Self::Error::InvalidHashedPagesCount {
+                    // We can't do `drive_size.to_page_count()` here, as the cast from u64
+                    // to u32 could fail.
+                    hashed_pages: if drive_size.0.div_ceil(PAGE_SIZE as u64) >= u32::MAX as u64 {
+                        Pages(u32::MAX)
+                    } else {
+                        drive_size.to_page_count()
+                    },
+                });
+            }
+
+            // The `drive_size` didn't overflow the maximum number of pages.
+            // Now check that adding the other sections is still in-bounds.
+
+            let hashed_pages = Pages(
+                user_data_length
+                    .to_page_count()
+                    .0
+                    .saturating_add(xvc_data_length.to_page_count().0)
+                    .saturating_add(dynamic_header_length.to_page_count().0)
+                    .saturating_add(drive_size.to_page_count().0),
+            );
+
+            if hashed_pages > MAX_HASHED_PAGES {
+                return Err(Self::Error::InvalidHashedPagesCount { hashed_pages });
+            }
+        }
 
         let (ext_entries, r) = r.read::<[XvdExtEntry; 4]>();
         let (capabilities, r) = r.read::<[U16; 8]>();

--- a/crates/msixvc/src/models/xvd/structs.rs
+++ b/crates/msixvc/src/models/xvd/structs.rs
@@ -699,13 +699,6 @@ impl XvdHeader {
         self.drive_size.to_page_count()
     }
 
-    pub fn number_of_hashed_pages(&self) -> Pages {
-        self.drive_page_count()
-            + self.user_data_page_count()
-            + self.xvc_data_page_count()
-            + self.dynamic_header_page_count()
-    }
-
     pub fn number_of_metadata_pages(&self) -> Pages {
         self.user_data_page_count() + self.xvc_data_page_count() + self.dynamic_header_page_count()
     }

--- a/crates/msixvc/src/models/xvd/structs.rs
+++ b/crates/msixvc/src/models/xvd/structs.rs
@@ -1,3 +1,4 @@
+use super::layout::MAX_HASHED_BYTES;
 use super::{
     WriteablePolicyFlags, XVD_HEADER_INCL_SIGNATURE_SIZE, XvcInfoFlags, XvcRegionFlags,
     XvcRegionId, XvcRegionPresenceInfoFlags, XvdContentType, XvdSegmentMetadataSegmentFlags,
@@ -78,6 +79,9 @@ pub enum XvdHeaderParseError {
 
     #[error("invalid xvd content type: {0}")]
     InvalidXvdContentType(#[from] TryFromPrimitiveError<XvdContentType>),
+
+    #[error("too large drive size: {drive_size:?}, the maximum is {MAX_HASHED_BYTES:?}")]
+    TooLargeDriveSize { drive_size: Bytes },
 }
 
 impl BinaryTryParse for XvdHeader {
@@ -96,6 +100,11 @@ impl BinaryTryParse for XvdHeader {
         let (format_version, r) = r.read::<U32>();
         let (file_time_created, r) = r.read::<Filetime>();
         let (drive_size, r) = r.read::<U64>();
+
+        let drive_size = Bytes(drive_size);
+        if drive_size > MAX_HASHED_BYTES {
+            return Err(Self::Error::TooLargeDriveSize { drive_size });
+        }
 
         let (vduid, r) = r.read::<Uuid>();
         let (uduid, r) = r.read::<Uuid>();
@@ -151,7 +160,7 @@ impl BinaryTryParse for XvdHeader {
                 volume_flags,
                 format_version,
                 file_time_created,
-                drive_size: Bytes(drive_size),
+                drive_size,
                 vduid,
                 uduid,
                 top_hash_block_hash,

--- a/crates/msixvc/src/xvd.rs
+++ b/crates/msixvc/src/xvd.rs
@@ -21,6 +21,7 @@ use zerocopy::IntoBytes;
 use crate::crypt::{TweakGenerator, decrypt_page_xts};
 use crate::layout::{Bytes, PAGE_SIZE, PAGES_PER_BLOCK, Pages};
 use crate::math::calculate_hash_block_num_and_run_for_block_num;
+use crate::models::xvd::layout::XvdLayout;
 use crate::models::xvd::{
     XvcInfo, XvcRegionHeader, XvcRegionId, XvdHashEntry, XvdHeader, XvdSegmentMetadataHeader,
     XvdSegmentMetadataSegment, XvdSegmentMetadataSegmentFlags, XvdUserDataHeader,
@@ -271,9 +272,8 @@ impl<R> Write for XvdStream<R> {
 }
 pub struct XvdFile {
     header: XvdHeader,
-    drive_data_offset: u64,
+    layout: XvdLayout,
     encrypted_section_infos: Vec<EncryptedSectionInfo>,
-    user_data_offset: u64,
 }
 
 #[derive(Debug)]
@@ -348,15 +348,13 @@ impl XvdFile {
             XvdHeader::try_from_array(&buf)?
         };
 
-        let mdu_offset = xvd_header.mdu_offset();
-        let (_hash_tree_levels, hash_tree_page_count) = xvd_header.hash_tree_info();
-        let xvc_info_offset = xvd_header.xvc_info_offset(hash_tree_page_count);
+        let layout = xvd_header.layout();
 
         let mut region_headers: Vec<XvcRegionHeader> = Vec::new();
 
         // TODO: Check if we have proper content type
-        if xvd_header.xvc_data_length > Bytes(0) {
-            file.seek(std::io::SeekFrom::Start(xvc_info_offset.0))
+        if layout.xvc_info.len > Bytes(0) {
+            file.seek(std::io::SeekFrom::Start(layout.xvc_info.start.to_bytes().0))
                 .await
                 .expect("Unable to seek");
 
@@ -378,17 +376,6 @@ impl XvdFile {
             }
         }
 
-        let hash_tree_offset = xvd_header.mutable_data_length() + mdu_offset;
-        let user_data_offset = if xvd_header.volume_flags.is_data_integrity_enabled() {
-            xvd_header.hash_tree_info().1.to_bytes()
-        } else {
-            Bytes(0)
-        } + hash_tree_offset;
-        let xvc_info_offset = xvd_header.user_data_page_count().to_bytes() + user_data_offset;
-        let dynamic_header_offset = xvd_header.xvc_data_page_count().to_bytes() + xvc_info_offset;
-        let drive_data_offset =
-            xvd_header.dynamic_header_page_count().to_bytes() + dynamic_header_offset;
-
         let mut enc_sections: Vec<EncryptedSectionInfo> = vec![];
         let mut reader = BufReader::with_capacity(PAGES_PER_BLOCK * XvdHashEntry::SIZE, file);
         for h in region_headers {
@@ -400,7 +387,7 @@ impl XvdFile {
                 Some(n) => todo!("KeyID other than 0 or unencrypted is not supported, found {n}"),
             }
 
-            let start_page = h.offset - user_data_offset.to_page_index();
+            let start_page = h.offset - layout.user_data.start;
             let mut data_units: Vec<u32> = Vec::with_capacity(num_pages as usize);
             let mut data_hashs: Vec<[u8; 20]> = Vec::with_capacity(num_pages as usize);
 
@@ -412,7 +399,7 @@ impl XvdFile {
                 let (hash_block, entry_start, run_length) =
                     calculate_hash_block_num_and_run_for_block_num(
                         xvd_header.xvd_type as u32,
-                        _hash_tree_levels,
+                        layout.hash_tree_layout.top_level() as u64 + 1,
                         xvd_header.number_of_hashed_pages(),
                         start_page.0 + page,
                         0,
@@ -421,7 +408,7 @@ impl XvdFile {
                     );
                 let run_length = min(run_length, num_pages - page);
                 page += run_length;
-                let read_offset = hash_tree_offset
+                let read_offset = layout.hash_tree.start.to_bytes()
                     + Pages(hash_block).to_bytes()
                     + Bytes(entry_start as u64 * XvdHashEntry::SIZE as u64);
                 reader.seek(SeekFrom::Start(read_offset.0)).await?;
@@ -447,9 +434,8 @@ impl XvdFile {
         }
         Ok(XvdFile {
             header: xvd_header,
-            drive_data_offset: drive_data_offset.0,
+            layout,
             encrypted_section_infos: enc_sections,
-            user_data_offset: user_data_offset.0,
         })
     }
 
@@ -462,7 +448,7 @@ impl XvdFile {
     {
         let mut files = HashMap::new();
 
-        let user_data_offset = self.user_data_offset;
+        let user_data_offset = self.layout.user_data.start.0 as u64;
         file.seek(SeekFrom::Start(user_data_offset)).await?;
         let user_data_header = {
             let mut buf = XvdUserDataHeader::buffer();
@@ -652,7 +638,7 @@ impl XvdFile {
     where
         Reader: AsyncRead + AsyncSeek + Unpin,
     {
-        let drive_data_offset = self.drive_data_offset;
+        let drive_data_offset = self.layout.drive_data.start.to_bytes().0;
         let drive_size = self.header.drive_size;
         let drive_plain_len = self.non_encrypted_prefix_len(drive_data_offset, drive_size.0);
 


### PR DESCRIPTION
I wasn't able to remove the remaining stuff in math.rs (yet), but this moves all the other computations to `models::xvd::layout`. The layout of the MSIXVC package is computed once at the start. The layout includes the start page and length in bytes of each section of the package, plus the layout of the Hash Tree.