### PR TITLE
feat: added protobuf example definition for XUserAdd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8599749b6667e2f0c910c1d0dff6901163ff698a52d5a39720f61b5be4b20d3"
 dependencies = [
  "futures-core",
- "prost",
+ "prost 0.14.4",
  "prost-types",
  "tonic",
  "tonic-prost",
@@ -871,7 +871,7 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "hyper-util",
- "prost",
+ "prost 0.14.4",
  "prost-types",
  "serde",
  "serde_json",
@@ -4312,12 +4312,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -4332,11 +4342,24 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.14.4",
  "prost-types",
  "regex",
  "syn 2.0.119",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4358,7 +4381,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -5991,7 +6014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.14.4",
  "tonic",
 ]
 
@@ -7149,7 +7172,7 @@ dependencies = [
  "num-bigint-dig 0.9.1",
  "num-integer",
  "num_enum",
- "prost",
+ "prost 0.14.4",
  "prost-build",
  "quick-xml 0.42.0",
  "rand 0.10.2",
@@ -7204,6 +7227,8 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "console-subscriber",
+ "prost 0.13.5",
+ "prost-build",
  "quick-xml 0.42.0",
  "reqwest 0.13.4",
  "serde_json",

--- a/crates/xodus-service/Cargo.toml
+++ b/crates/xodus-service/Cargo.toml
@@ -15,6 +15,10 @@ console-subscriber = { workspace = true, optional = true }
 quick-xml = { version = "0.42.0", features = ["serialize", "overlapped-lists"] }
 tokio-util = "0.7.19"
 serde_json = "1.0.151"
+prost = "0.13"
 
 [features]
 tokio_console = ["dep:console-subscriber"]
+
+[build-dependencies]
+prost-build = "0.14.4"

--- a/crates/xodus-service/build.rs
+++ b/crates/xodus-service/build.rs
@@ -1,0 +1,5 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=proto/");
+    prost_build::compile_protos(&["proto/common.proto", "proto/xuser.proto"], &["proto"])?;
+    Ok(())
+}

--- a/crates/xodus-service/proto/README.md
+++ b/crates/xodus-service/proto/README.md
@@ -1,0 +1,4 @@
+This folder contains the `.proto` definitions for xgameruntime requests and responses.
+
+- `common.proto` - contains the container XodusRequest and XodusResponse definitions, which contain a payload field that corresponds to a more specific request / response.
+- `xuser.proto` - contains requests mapping to the parameters for XUser functions and responses mapping to the return values of async XUser functions. For non-async functions, a generic XUserResponse should be used.

--- a/crates/xodus-service/proto/README.md
+++ b/crates/xodus-service/proto/README.md
@@ -2,3 +2,10 @@ This folder contains the `.proto` definitions for xgameruntime requests and resp
 
 - `common.proto` - contains the container XodusRequest and XodusResponse definitions, which contain a payload field that corresponds to a more specific request / response.
 - `xuser.proto` - contains requests mapping to the parameters for XUser functions and responses mapping to the return values of async XUser functions. For non-async functions, a generic XUserResponse should be used.
+
+Prost will generate names in pascal case, i.e the variable name `xuser_add_req` will become `XuserAddReq`.
+
+## Conversion Notes
+
+- Parameters to a function noted as `_Out_` in the documentation should be part of the corresponding response payload. 
+- Adhere to Protocol Buffers style guide

--- a/crates/xodus-service/proto/common.proto
+++ b/crates/xodus-service/proto/common.proto
@@ -1,7 +1,7 @@
 /* definitions of container requests and responses and shared enums */
 
 syntax = "proto3";
-package xodus;
+package xodus_proto;
 
 import "xuser.proto";
 

--- a/crates/xodus-service/proto/common.proto
+++ b/crates/xodus-service/proto/common.proto
@@ -1,0 +1,30 @@
+/* definitions of container requests and responses and shared enums */
+
+syntax = "proto3";
+package xodus;
+
+import "xuser.proto";
+
+/* Request to Xodus from a client (i.e Wine) */
+message XodusRequest {
+  uint64 request_id = 1;
+  oneof payload {
+    XUserAddRequest xuser_add_req = 10;
+  }
+}
+
+/* Response from Xodus to a client */
+message XodusResponse {
+  uint64 request_id = 1;
+  HRESULT status_code = 2;
+  oneof payload {
+    XUserAddResponse xuser_add_res = 10;
+  }
+}
+
+/* hresult, only some response codes */
+/* full codes: https://learn.microsoft.com/en-us/gaming/gdk/docs/reference/live/xbl-hresult-error-codes?view=gdk-2604 */
+enum HRESULT {
+    HRESULT_UNSPECIFIED = 0;
+    HRESULT_S_OK = 1;
+}

--- a/crates/xodus-service/proto/xuser.proto
+++ b/crates/xodus-service/proto/xuser.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package xodus;
+package xodus_proto;
 
 /* XUserAddAsync - https://learn.microsoft.com/en-us/gaming/gdk/docs/reference/system/xuser/functions/xuseraddasync?view=gdk-2604 */
 message XUserAddRequest {

--- a/crates/xodus-service/proto/xuser.proto
+++ b/crates/xodus-service/proto/xuser.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package xodus;
+
+/* XUserAddAsync - https://learn.microsoft.com/en-us/gaming/gdk/docs/reference/system/xuser/functions/xuseraddasync?view=gdk-2604 */
+message XUserAddRequest {
+    int32 options = 1;
+}
+
+/* XUserAddResult - https://learn.microsoft.com/en-us/gaming/gdk/docs/reference/system/xuser/functions/xuseraddresult?view=gdk-2604 */
+/* hresult is provided as part of the XodusResponse definition */
+message XUserAddResponse {
+    uint64 user_handle = 1;
+}

--- a/crates/xodus-service/proto/xuser.proto
+++ b/crates/xodus-service/proto/xuser.proto
@@ -1,13 +1,160 @@
 syntax = "proto3";
 package xodus_proto;
 
-/* XUserAddAsync - https://learn.microsoft.com/en-us/gaming/gdk/docs/reference/system/xuser/functions/xuseraddasync?view=gdk-2604 */
 message XUserAddRequest {
-    int32 options = 1;
+  XUserAddOptions options = 1;
+}
+message XUserAddResponse {
+  uint64 user_handle = 1;
 }
 
-/* XUserAddResult - https://learn.microsoft.com/en-us/gaming/gdk/docs/reference/system/xuser/functions/xuseraddresult?view=gdk-2604 */
-/* hresult is provided as part of the XodusResponse definition */
-message XUserAddResponse {
-    uint64 user_handle = 1;
+message XUserAddByIdWithUiRequest {
+  uint64 user_id = 1;
+}
+message XUserAddByIdWithUiResponse {
+  uint64 user_handle = 1;
+}
+
+message XUserChangeEventCallback {}
+
+message XUserCheckPrivilegeRequest {
+  uint64 user = 1;
+  XUserPrivilegeOptions options = 2;
+  XUserPrivilege privilege = 3;
+}
+message XUserCheckPrivilegeResponse {
+  bool has_privilege = 1;
+  XUserPrivilegeDenyReason reason = 2;
+}
+
+message XUserCloseHandleRequest {}
+
+message XUserCloseSignOutDeferralHandleRequest {}
+
+message XUserCompareRequest {
+  uint64 user1 = 1;
+  uint64 user2 = 2;
+}
+message XUserCompareResponse {
+  int32 equal = 1;
+}
+
+message XUserDefaultAudioEndpointUtf16ChangedCallbackRequest {}
+
+message XUserDeviceAssociationChangedCallbackRequest {}
+
+message XUserDuplicateHandleRequest {
+  int64 user1 = 1;
+}
+message XUserDuplicateHandleResponse {
+  int64 duplicated_handle = 1;
+}
+
+message XUserFindControllerForUserWithUiRequest {}
+
+message XUserFindForDeviceRequest {}
+
+message XUserFindUserByIdRequest {
+  int64 user_id = 1;
+}
+message XUserFindUserByIdResponse {
+  int64 handle = 1;
+}
+
+message XUserFindUserByLocalIdRequest {
+  int64 user_local_id = 1;
+}
+message XUserFindUserByLocalIdResponse {
+  int64 handle = 1;
+}
+
+message XUserGetAgeGroupRequest {
+  int64 user = 1;
+}
+message XUserGetAgeGroupResponse {
+  XUserAgeGroup age_group = 1;
+}
+
+message XUserGetDefaultAudioEndpointUtf16 {}
+
+message XUserGetGamerPictureRequest {}
+message XUserGetGamerPictureResponse {}
+
+message XUserGetGamerPictureResultSizeRequest {}
+
+message XUserGetGamertagRequest {}
+
+message XUserGetIdRequest {}
+
+message XUserGetIsGuestRequest {}
+
+message XUserGetLocalIdRequest {}
+
+message XUserGetMaxUsersRequest {}
+
+message XUserGetMsaTokenSilentlyAsyncRequest {}
+message XUserGetMsaTokenSilentlyAsyncResponse {}
+
+message XUserGetSignOutDeferralRequest {}
+
+message XUserGetStateRequest {}
+
+message XUserGetTokenAndSignatureRequest {}
+message XUserGetTokenAndSignatureResponse {}
+
+message XUserIsStoreUserRequest {}
+
+message XUserRegisterForChangeEventRequest {}
+
+/* enumerations */
+
+enum XUserAddOptions {
+  X_USER_ADD_OPTIONS_UNSPECIFIED = 0;
+  X_USER_ADD_OPTIONS_ADD_DEFAULT_USER_SILENTLY = 1;
+  X_USER_ADD_OPTIONS_ALLOW_GUESTS = 2;
+  X_USER_ADD_OPTIONS_ADD_DEFAULT_USER_ALLOWING_UI = 4;
+}
+
+enum XUserAgeGroup {
+  X_USER_AGE_GROUP_UNSPECIFIED = 0;
+  X_USER_AGE_GROUP_CHILD = 1;
+  X_USER_AGE_GROUP_TEEN = 2;
+  X_USER_AGE_GROUP_ADULT = 3;
+}
+
+enum XUserPrivilegeOptions {
+  X_USER_PRIVILEGE_OPTIONS_UNSPECIFIED = 0;
+  X_USER_PRIVILEGE_OPTIONS_ALL_USERS = 1;
+}
+
+enum XUserState {
+  X_USER_STATE_UNSPECIFIED = 0;
+  X_USER_STATE_SIGNING_OUT = 1;
+  X_USER_STATE_SIGNED_OUT = 2;
+}
+
+enum XUserPrivilege {
+  X_USER_PRIVILEGE_UNSPECIFIED = 0;
+  X_USER_PRIVILEGE_CROSS_PLAY = 185;
+  X_USER_PRIVILEGE_CLUBS = 188;
+  X_USER_PRIVILEGE_SESSIONS = 189;
+  X_USER_PRIVILEGE_BROADCAST = 190;
+  X_USER_PRIVILEGE_MANAGE_PROFILE_PRIVACY = 196;
+  X_USER_PRIVILEGE_GAME_DVR = 198;
+  X_USER_PRIVILEGE_MULTIPLAYER_PARTIES = 203;
+  X_USER_PRIVILEGE_CLOUD_MANAGE_SESSION = 207;
+  X_USER_PRIVILEGE_CLOUD_JOIN_SESSION = 208;
+  X_USER_PRIVILEGE_CLOUD_SAVED_GAMES = 209;
+  X_USER_PRIVILEGE_SOCIAL_NETWORK_SHARING = 220;
+  X_USER_PRIVILEGE_USER_GENERATED_CONTENT = 247;
+  X_USER_PRIVILEGE_COMMUNICATIONS = 252;
+  X_USER_PRIVILEGE_MULTIPLAYER = 254;
+  X_USER_PRIVILEGE_ADD_FRIENDS = 255;
+}
+
+enum XUserPrivilegeDenyReason {
+  X_USER_PRIVILEGE_DENY_REASON_UNSPECIFIED = 0;
+  X_USER_PRIVILEGE_DENY_REASON_PURCHASE_REQUIRED = 1;
+  X_USER_PRIVILEGE_DENY_REASON_RESTRICTED = 2;
+  X_USER_PRIVILEGE_DENY_REASON_BANNED = 3;
 }

--- a/crates/xodus-service/src/connection/router.rs
+++ b/crates/xodus-service/src/connection/router.rs
@@ -31,7 +31,7 @@ pub async fn route(
         let magic = u32::from_le_bytes(read_magic);
         let res = match magic {
             crate::XML_MAGIC => super::xml::handle(&mut socket, &mut context).await,
-            crate::PROTO_MAGIC => super::proto::handle(&mut socket, &mut context).await,
+            crate::PROTO_MAGIC => crate::handlers::message::handle(&mut socket, &mut context).await,
             _ => {
                 tracing::error!("Unknown magic");
                 return;

--- a/crates/xodus-service/src/handlers/message.rs
+++ b/crates/xodus-service/src/handlers/message.rs
@@ -1,14 +1,16 @@
 use crate::simple_context::SimpleContext;
 use crate::xodus_proto::{
-    XodusRequest, xodus_request::Payload as ReqType, xodus_response::Payload as ResType,
+    Hresult, XodusRequest, XodusResponse, xodus_request::Payload as ReqType,
+    xodus_response::Payload as ResType,
 };
-use crate::xruntime::user;
+use prost::Message;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 // Generic message handler - read from socket and redirect message to specific handler.
 pub async fn handle(
     socket: &mut tokio::net::UnixStream,
     context: &mut SimpleContext,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> tokio::io::Result<()> {
     // header
     let mut len_buf = [0u8; 4];
     socket.read_exact(&mut len_buf).await?;
@@ -24,12 +26,14 @@ pub async fn handle(
     let payload = request.payload;
 
     let response_payload = match payload {
-        ReqType::XUserAddRequest(req) => {
+        Some(ReqType::XuserAddReq(req)) => {
             let response =
                 crate::handlers::user::handle_xuseradd(req, context.tokens().clone()).await;
-            ResType::XUserAddResponse(response)
+            ResType::XuserAddRes(response)
         }
-        _ => return Err("Unhandled request payload type".into()),
+        _ => todo!("Error handling sill sucks"),
     };
+
+    // respond here
     Ok(())
 }

--- a/crates/xodus-service/src/handlers/message.rs
+++ b/crates/xodus-service/src/handlers/message.rs
@@ -1,0 +1,35 @@
+use crate::simple_context::SimpleContext;
+use crate::xodus_proto::{
+    XodusRequest, xodus_request::Payload as ReqType, xodus_response::Payload as ResType,
+};
+use crate::xruntime::user;
+
+// Generic message handler - read from socket and redirect message to specific handler.
+pub async fn handle(
+    socket: &mut tokio::net::UnixStream,
+    context: &mut SimpleContext,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // header
+    let mut len_buf = [0u8; 4];
+    socket.read_exact(&mut len_buf).await?;
+
+    // message
+    let length = u32::from_be_bytes(len_buf) as usize;
+    let mut payload_buf = vec![0u8; length];
+    socket.read_exact(&mut payload_buf).await?;
+
+    // decode request
+    let request = XodusRequest::decode(payload_buf.as_slice())?;
+    let request_id = request.request_id;
+    let payload = request.payload;
+
+    let response_payload = match payload {
+        ReqType::XUserAddRequest(req) => {
+            let response =
+                crate::handlers::user::handle_xuseradd(req, context.tokens().clone()).await;
+            ResType::XUserAddResponse(response)
+        }
+        _ => return Err("Unhandled request payload type".into()),
+    };
+    Ok(())
+}

--- a/crates/xodus-service/src/handlers/message.rs
+++ b/crates/xodus-service/src/handlers/message.rs
@@ -25,6 +25,7 @@ pub async fn handle(
     let request_id = request.request_id;
     let payload = request.payload;
 
+    // get the response payload from handler
     let response_payload = match payload {
         Some(ReqType::XuserAddReq(req)) => {
             let response =
@@ -33,6 +34,19 @@ pub async fn handle(
         }
         _ => todo!("Error handling sill sucks"),
     };
+
+
+    let response = XodusResponse {
+        request_id,
+        status_code: Hresult::SOk as i32,
+        payload: Some(response_payload)
+    };
+
+    let mut response_buf = Vec::new();
+    response.encode(&mut response_buf)?;
+    let len_bytes = (response_buf.len() as u32).to_be_bytes();
+    socket.write_all(&len_bytes).await?;
+    socket.write_all(&response_buf).await?;
 
     // respond here
     Ok(())

--- a/crates/xodus-service/src/handlers/message.rs
+++ b/crates/xodus-service/src/handlers/message.rs
@@ -11,7 +11,8 @@ pub async fn handle(
     socket: &mut tokio::net::UnixStream,
     context: &mut SimpleContext,
 ) -> tokio::io::Result<()> {
-    // header
+    // header, I believe the magic at this point as already been read, so just focus on getting
+    // message size
     let mut len_buf = [0u8; 4];
     socket.read_exact(&mut len_buf).await?;
 
@@ -35,19 +36,20 @@ pub async fn handle(
         _ => todo!("Error handling sill sucks"),
     };
 
-
+    // build out response using the created payload from handler
     let response = XodusResponse {
         request_id,
         status_code: Hresult::SOk as i32,
-        payload: Some(response_payload)
+        payload: Some(response_payload),
     };
 
+    // write back
     let mut response_buf = Vec::new();
     response.encode(&mut response_buf)?;
     let len_bytes = (response_buf.len() as u32).to_be_bytes();
     socket.write_all(&len_bytes).await?;
     socket.write_all(&response_buf).await?;
 
-    // respond here
+    // better return values here
     Ok(())
 }

--- a/crates/xodus-service/src/handlers/mod.rs
+++ b/crates/xodus-service/src/handlers/mod.rs
@@ -1,0 +1,2 @@
+pub mod message;
+pub mod user;

--- a/crates/xodus-service/src/handlers/user.rs
+++ b/crates/xodus-service/src/handlers/user.rs
@@ -6,6 +6,7 @@ use xodus::tokens::TokenManager;
 // user specific handlers
 pub async fn handle_xuseradd(req: XUserAddRequest, tokens: Arc<TokenManager>) -> XUserAddResponse {
     // stub
+
     XUserAddResponse {
         user_handle: 0x1337,
     }

--- a/crates/xodus-service/src/handlers/user.rs
+++ b/crates/xodus-service/src/handlers/user.rs
@@ -1,0 +1,13 @@
+use crate::xodus_proto::XUserAddRequest;
+use crate::xodus_proto::XUserAddResponse;
+use std::sync::Arc;
+use xodus::tokens::TokenManager;
+
+// user specific handlers
+pub async fn handle_xuseradd(req: XUserAddRequest, tokens: Arc<TokenManager>) -> XUserAddResponse {
+    // stub
+
+    XUserAddResponse {
+        user_handle: 0x1337,
+    }
+}

--- a/crates/xodus-service/src/handlers/user.rs
+++ b/crates/xodus-service/src/handlers/user.rs
@@ -6,7 +6,6 @@ use xodus::tokens::TokenManager;
 // user specific handlers
 pub async fn handle_xuseradd(req: XUserAddRequest, tokens: Arc<TokenManager>) -> XUserAddResponse {
     // stub
-
     XUserAddResponse {
         user_handle: 0x1337,
     }

--- a/crates/xodus-service/src/main.rs
+++ b/crates/xodus-service/src/main.rs
@@ -13,6 +13,11 @@ mod connection;
 pub mod handlers;
 mod simple_context;
 mod utils;
+
+pub mod xodus_proto {
+    include!(concat!(env!("OUT_DIR"), "/xodus_proto.rs"));
+}
+
 const XML_MAGIC: u32 = 0x58445358;
 const PROTO_MAGIC: u32 = 0x58445350;
 

--- a/crates/xodus-service/src/main.rs
+++ b/crates/xodus-service/src/main.rs
@@ -10,9 +10,9 @@ use tracing_subscriber::util::SubscriberInitExt;
 use xodus::tokens::TokenManager;
 
 mod connection;
+pub mod handlers;
 mod simple_context;
 mod utils;
-
 const XML_MAGIC: u32 = 0x58445358;
 const PROTO_MAGIC: u32 = 0x58445350;
 


### PR DESCRIPTION
added in example design for protobuf implementation within services. the idea is that these definitions would also be used by the runtime to send and receive messages between processes, with messages mapping to the appropriate xgameruntime function.

opening as a draft due to some issues compiling due to dependency structure. 