### PR TITLE
Friend requests

### DIFF
--- a/crates/xodus-cli/src/commands.rs
+++ b/crates/xodus-cli/src/commands.rs
@@ -7,5 +7,6 @@ pub mod login;
 pub mod logout;
 #[cfg(unix)]
 pub mod run;
+pub mod friend;
 pub mod splicense;
 pub mod streaming;

--- a/crates/xodus-cli/src/commands/friend.rs
+++ b/crates/xodus-cli/src/commands/friend.rs
@@ -1,0 +1,74 @@
+use std::process::ExitCode;
+use reqwest::{RequestBuilder, Response};
+use reqwest::header::AUTHORIZATION;
+use reqwest::StatusCode;
+use xodus::api::xbox;
+use xodus::api::xbox::auth::get_xsts_auth_header;
+use xodus::models::secrets::Token;
+use xodus::models::xbox::social::{AddFriendResponse, RemoveFriendResponse};
+use xodus::tokens::TokenManager;
+
+const SOCIAL_XBOXLIVE: &str = "https://social.xboxlive.com/users/me/people";
+
+async fn authorize_and_send(
+    client: &reqwest::Client,
+    tokens: &TokenManager,
+    request: RequestBuilder,
+) -> reqwest::Result<Response> {
+    let Token::Legacy(device_token) = tokens.get_device_sts_token().unwrap() else { panic!("unsupported device token") };
+    let Token::Legacy(user_token) = tokens.get_user_sts_token().unwrap() else { panic!("unsupported user token") };
+
+    let xsts_token = xbox::run(
+        client,
+        device_token,
+        user_token,
+        "http://xboxlive.com",
+    ).await;
+
+    let auth_header = get_xsts_auth_header(xsts_token);
+    request
+        .header("x-xbl-contract-version", "3")
+        .header(AUTHORIZATION, auth_header)
+        .send().await?
+        .error_for_status()
+}
+
+pub async fn add(client: &reqwest::Client, tokens: &TokenManager, xuid: String) -> ExitCode {
+    let request = client.put(format!("{SOCIAL_XBOXLIVE}/friends/v2/xuid({})", xuid));
+    let response = authorize_and_send(client, tokens, request).await.unwrap();
+    let response: AddFriendResponse = response.json().await.expect("Failed to parse response.");
+    println!("{:?}", response);
+    ExitCode::SUCCESS
+}
+
+pub async fn remove(client: &reqwest::Client, tokens: &TokenManager, xuid: String) -> ExitCode {
+    let request = client.delete(format!("{SOCIAL_XBOXLIVE}/friends/v2/xuid({})?deleteRelationships=friends", xuid));
+    let response = authorize_and_send(client, tokens, request).await.unwrap();
+    let response: RemoveFriendResponse = response.json().await.expect("Failed to parse response.");
+    println!("{:?}", response);
+    ExitCode::SUCCESS
+}
+
+pub async fn follow(client: &reqwest::Client, tokens: &TokenManager, xuid: String) -> ExitCode {
+    let request = client.put(format!("{SOCIAL_XBOXLIVE}/xuid({})", xuid));
+    let response = authorize_and_send(client, tokens, request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    ExitCode::SUCCESS
+}
+
+pub async fn unfollow(client: &reqwest::Client, tokens: &TokenManager, xuid: String) -> ExitCode {
+    let request = client.delete(format!("{SOCIAL_XBOXLIVE}/friends/v2/xuid({})?deleteRelationships=follows", xuid));
+    let response = authorize_and_send(client, tokens, request).await.unwrap();
+    let response: RemoveFriendResponse = response.json().await.expect("Failed to parse response.");
+    println!("{:?}", response);
+    ExitCode::SUCCESS
+}
+
+pub async fn remove_follower(client: &reqwest::Client, tokens: &TokenManager, xuid: String) -> ExitCode {
+    let request = client.delete(format!("{SOCIAL_XBOXLIVE}/follower/xuid({})", xuid));
+    let response = authorize_and_send(client, tokens, request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    ExitCode::SUCCESS
+}
+
+

--- a/crates/xodus-cli/src/main.rs
+++ b/crates/xodus-cli/src/main.rs
@@ -80,6 +80,12 @@ enum SubCommand {
         #[arg(short, long)]
         market: Option<String>,
     },
+    #[command(about = "Add or remove friends and followers")]
+    Friend  {
+        #[command(subcommand)]
+        action: FriendAction,
+        xuid: String,
+    },
     #[command(about = "Generate or decrypt base64-encoded CLEP challenge data")]
     Clep {
         #[command(subcommand)]
@@ -89,6 +95,17 @@ enum SubCommand {
     SpLicense {
         block: String,
     },
+}
+
+#[derive(Subcommand)]
+enum FriendAction {
+    #[command(about = "Offer or accept a friend request")]
+    Add,
+    #[command(about = "Cancel a friend request or remove friend")]
+    Remove,
+    Follow,
+    Unfollow,
+    RemoveFollower,
 }
 
 #[derive(Subcommand)]
@@ -233,6 +250,13 @@ async fn main() -> ExitCode {
             exe,
             market,
         } => commands::run::run(&client, &tokens, source, wine, exe, market).await,
+        SubCommand::Friend { action, xuid } => match action {
+            FriendAction::Add => commands::friend::add(&client, &tokens, xuid).await,
+            FriendAction::Remove => commands::friend::remove(&client, &tokens, xuid).await,
+            FriendAction::Follow => commands::friend::follow(&client, &tokens, xuid).await,
+            FriendAction::Unfollow => commands::friend::unfollow(&client, &tokens, xuid).await,
+            FriendAction::RemoveFollower => commands::friend::remove_follower(&client, &tokens, xuid).await,
+        },
         SubCommand::Clep { action } => match action {
             ClepAction::Generate {
                 smbios,

--- a/crates/xodus/src/models/xbox.rs
+++ b/crates/xodus/src/models/xbox.rs
@@ -1,6 +1,9 @@
+pub mod social;
 pub mod subscriptions;
 
 use serde::{Deserialize, Serialize};
+
+pub struct Xuid(String);
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "PascalCase")]

--- a/crates/xodus/src/models/xbox/social.rs
+++ b/crates/xodus/src/models/xbox/social.rs
@@ -1,0 +1,18 @@
+use chrono::DateTime;
+use serde::{Deserialize, Serialize};
+use super::Xuid;
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AddFriendResponse {
+    pub xuid: Xuid,
+    pub added_date_time_utc: DateTime<chrono::Utc>,
+    pub friend_request_sent: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct RemoveFriendResponse {
+    pub xuid: Xuid,
+}
+


### PR DESCRIPTION
Added the friend command with the following sub-commands:
- add        
- remove
- follow       
- unfollow
- remove-follower

For example, to send me a friend request: `./xodus-cli friend 2535412854559864 add`

- [x] social.xboxlive.com (send friend requests by xuid)
- [ ] peoplehub.xboxlive.com (list current friends, search by gamer-tag)
- [ ] notificationinbox.xboxlive.com (read incoming friend request)